### PR TITLE
feat: enlarge the home hero on mobile

### DIFF
--- a/styles/_variables.scss
+++ b/styles/_variables.scss
@@ -135,7 +135,10 @@ $stagger: 80ms;
 // Fluid type scale — interpolates between 375px and 1440px viewports, clamped
 // at both ends so it stops growing on very wide screens.
 // ---------------------------------------------------------------------------
-$fs-display: clamp(3rem, 0.6rem + 10.2vw, 9rem);
+// Below ~379px the hero is bound by its longest word (CRIMINAL) against the
+// container, so it tracks pure vw and holds a constant fill instead of going
+// flat and clipping on 320px screens. Above that, the usual fluid line to 144.
+$fs-display: min(17vw, 2.25rem + 7.5vw, 9rem);
 $fs-display-sub: clamp(0.75rem, 0.706rem + 0.188vw, 0.875rem);
 // Page banners and section headings are deliberately oversized — the titles
 // are the ornament now, so they run well past ordinary heading scale.


### PR DESCRIPTION
## Motivation

`$fs-display` used `clamp(3rem, …)`, so the home hero stopped shrinking below a 375px viewport and sat flat at 48px — filling only 82% of the container on a 320px screen, where the whole point of the design is a name that dominates the page.

## Solution

Replaced the clamp with `min(17vw, 2.25rem + 7.5vw, 9rem)`: the `17vw` term wins below ~379px and keeps the hero proportional to the container (94% fill at every width — 64px at 375px, 54px at 320px), while the linear term takes over above that and still lands on exactly 144px at 1440px, so desktop is untouched. The two lines meet at ~379px, so there's no cliff and no breakpoint-specific font size. Sizing is bound by the longest word (`CRIMINAL` in the en locale) against the 90% container — past 94% fill it clips rather than wraps.

Verified with `yarn lint` and `yarn build` (both clean) plus screenshots at true 320/375 viewports in `fr` and `en` and at 1440 desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)