### PR TITLE
feat: drop the 01 index above the home about heading

### DIFF
--- a/pages/Home.module.scss
+++ b/pages/Home.module.scss
@@ -166,13 +166,6 @@ a.herofootitem:hover {
   font-size: 1rem;
 }
 
-.sectionindex {
-  @include micro;
-  color: $ink-muted;
-  display: block;
-  margin-bottom: $space-3;
-}
-
 .descinner p {
   max-width: $measure;
   color: $ink-muted;

--- a/pages/index.js
+++ b/pages/index.js
@@ -90,7 +90,6 @@ export default function Home({ data }) {
         </div>
         <div className={`${classes.desc}`}>
           <div className={classes.descinner}>
-            <span className={classes.sectionindex}>01</span>
             {sectionTitle && (
               <h2 className={classes.bottomtitle}>{sectionTitle?.trim()}</h2>
             )}


### PR DESCRIPTION
## Motivation

The home page's about section rendered a hardcoded `01` micro-label directly above its heading, which reads "Alice Ouaknine" — numbering a name that is the only item in its section.

## Solution

Removed the `sectionindex` span from `pages/index.js` and its now-dead rule from `pages/Home.module.scss`; `.bottomtitle` already carries `margin-top: 0`, so the heading sits flush with no spacing change. The hero practice list keeps its `01 / 02 / 03` numbering. `yarn lint` and `yarn build` pass.