### PR TITLE
feat: bring back the articles as a publications section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,8 +7,8 @@ that look small are usually design decisions.
 ## The project
 
 Marketing site for **Alice Ouaknine**, a criminal-law practice in Paris (17 rue
-de Douai, 75009). Bilingual `fr` / `en`. Four pages: home, expertise, contact,
-legal, plus a 404.
+de Douai, 75009). Bilingual `fr` / `en`. Six pages: home, expertise,
+publications, contact, iska, legal, plus a 404.
 
 | | |
 |---|---|
@@ -23,10 +23,16 @@ yarn install --frozen-lockfile
 yarn dev      # next dev
 yarn build    # next build
 yarn lint     # next lint
+yarn test     # node --test
 ```
 
-Run `yarn lint` and `yarn build` before calling anything done. There is no test
-suite; the build's typecheck and lint are the only automated gates.
+Run `yarn lint`, `yarn test` and `yarn build` before calling anything done.
+
+There is no component or end-to-end suite; the build's typecheck and lint carry
+most of the weight. `yarn test` covers one thing: the pure derivations in
+`libs/slug.js` and `libs/publication-fields.js`, which turn a title into every
+URL, hreflang and `@id` on the site and fail silently into a 404 when they
+break. They already broke once. Node's own runner, no dependencies, no config.
 
 ## Local development: read this before you try to run it
 
@@ -78,9 +84,13 @@ Two traps that have already cost time:
 
 ## Publications
 
-`/publications` renders the Sanity `post` documents: the firm's own writing
-(`filter: fact`, grouped into guides by the `series` field) and press mentions
-(`filter: press`). Anyone writing for it works from
+`/publications` renders the Sanity `post` documents: the firm's own writing and
+press mentions. Which is which is decided by `filter`, and by whether the
+document carries someone else's URL in `source`.
+
+Guides group themselves by the series name parsed out of the episode title
+(`<Guide> - Épisode <n> : <subtitle>`), because the studio carries no `series`
+field yet; the field takes over once it is added. Anyone writing for it works from
 `docs/publications-editorial-brief.md`, which carries the house format, the
 déontologie constraints, the full article list and the release schedule.
 
@@ -220,8 +230,6 @@ call button). Adding a fourth should need a reason.
 - `public/images/_50A7988_1.jpeg` (5.3MB) and `logodraft.svg` are unreferenced.
 - `public/images/paris-map.svg` is 810KB raw / ~254KB gzipped — the heaviest
   asset on the site. SVGO would likely halve it.
-- The footer and contact page use two slightly different Google Maps URLs for
-  the same address.
 - Legacy tokens (`$white`, `$gray*`, `$cyan*`) still sit in `_variables.scss`;
   `$green600` and `$amber600` are genuinely used by form status icons.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,14 @@ Two traps that have already cost time:
   page once with `curl`, wait, *then* capture. A stale capture has more than once
   looked like a CSS bug that was already fixed.
 
+## Publications
+
+`/publications` renders the Sanity `post` documents: the firm's own writing
+(`filter: fact`, grouped into guides by the `series` field) and press mentions
+(`filter: press`). Anyone writing for it works from
+`docs/publications-editorial-brief.md`, which carries the house format, the
+déontologie constraints, the full article list and the release schedule.
+
 ## Content: two sources, know which is which
 
 **Sanity** (`libs/clientApi.js`, GROQ in each page's `getStaticProps`) holds page

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,13 +26,24 @@ yarn lint     # next lint
 yarn test     # node --test
 ```
 
-Run `yarn lint`, `yarn test` and `yarn build` before calling anything done.
+Run `yarn lint`, `yarn test` and `yarn build` before calling anything done, and
+know what each one does and does not cover.
 
-There is no component or end-to-end suite; the build's typecheck and lint carry
-most of the weight. `yarn test` covers one thing: the pure derivations in
-`libs/slug.js` and `libs/publication-fields.js`, which turn a title into every
-URL, hreflang and `@id` on the site and fail silently into a 404 when they
-break. They already broke once. Node's own runner, no dependencies, no config.
+**There is no typecheck.** No TypeScript, no `tsconfig.json`, so `next build`
+checks nothing beyond compiling.
+
+**`next lint` walks only what it is told to.** Its default directory list is
+`pages`, `components`, `lib`, `src`. This repo's is `libs` (plural), so for a
+long time nothing in it was linted at all; the `lint` script now passes
+`--dir pages --dir components --dir libs`. Adding a top-level directory means
+adding it there too.
+
+**`yarn test` covers the pure derivations** in `libs/slug.js`, `libs/href.js` and
+`libs/publication-fields.js`: the functions that turn a title into every URL,
+hreflang and `@id` on the site, and that decide whether a CMS-authored link is
+same-site or hostile. They fail silently into a 404 or an unsafe anchor, and one
+of them already broke once. Node's own runner, no dependencies, no config. There
+is no component or end-to-end suite.
 
 ## Local development: read this before you try to run it
 
@@ -100,8 +111,9 @@ déontologie constraints, the full article list and the release schedule.
 copy — titles, body rich text, the expertise list. Editable by the client.
 
 **`content/*.json`** holds UI strings and contact facts, keyed by locale.
-`footerContent.json` is the canonical store for address, phone, mobile and email;
-it is read by both the home colophon and the contact page. Add contact details
+`footerContent.json` is the canonical store for the address, phone, mobile,
+email, the Google Maps URL and the geo coordinates; it is read by the home
+colophon, the contact page, the footer and the structured data. Add contact details
 there, not inline in a component.
 
 ### Orphaned Sanity fields
@@ -196,13 +208,14 @@ the cursor.
 1. Bodoni headlines
 2. Inter micro-labels
 3. Hairline rules (`$rule`)
-4. Numeric index — `01 / 02 / 03` on the home practice list and expertise accordion
+4. Numeric index — `01 / 02 / 03` on the home practice list, the expertise
+   accordion, the publications index and a guide's episode rail
 5. The ink-illustration portrait
 6. The ISKA wordmark
 
-Both list-style surfaces share one row shape: a micro-caps label gutter, the
-value beside it, a rule beneath. The contact details and the home practice list
-are the same pattern — keep them that way.
+Four surfaces share one row shape: a micro-caps label gutter, the value beside
+it, a rule beneath. The home practice list, the contact details, the publications
+index and a guide's episode rail are all the same pattern — keep them that way.
 
 **Deliberately removed. Do not reintroduce without asking:** diagonal
 `clip-path` panels, the scales-of-justice line drawing, decorative photography,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,8 +35,8 @@ checks nothing beyond compiling.
 **`next lint` walks only what it is told to.** Its default directory list is
 `pages`, `components`, `lib`, `src`. This repo's is `libs` (plural), so for a
 long time nothing in it was linted at all; the `lint` script now passes
-`--dir pages --dir components --dir libs`. Adding a top-level directory means
-adding it there too.
+`--dir pages --dir components --dir libs --dir hooks --dir context`. Adding a
+top-level directory means adding it there too.
 
 **`yarn test` covers the pure derivations** in `libs/slug.js`, `libs/href.js` and
 `libs/publication-fields.js`: the functions that turn a title into every URL,

--- a/components/head/head-page.jsx
+++ b/components/head/head-page.jsx
@@ -3,10 +3,11 @@ import { useRouter } from 'next/router';
 
 import { localeHref } from '../../libs/localePath';
 
-// A missing env var would otherwise publish `undefined/expertise/...` as a
-// canonical, which is invisible in review and expensive in the index.
-export const HOST =
-  process.env.NEXT_PUBLIC_HOST ?? 'https://www.ouaknine-avocats.com';
+import { SITE_URL } from '../../libs/site';
+
+// Re-exported: this was the third copy of the same expression, and the copies
+// disagreed about whether a blank env var counts as missing.
+export const HOST = SITE_URL;
 
 const OG_LOCALE = { fr: 'fr_FR', en: 'en_US' };
 

--- a/components/head/json-ld.jsx
+++ b/components/head/json-ld.jsx
@@ -10,7 +10,12 @@ function JsonLd({ id, data }) {
       <script
         key={id}
         type='application/ld+json'
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+        // `</script>` inside CMS prose would otherwise close this element and
+        // the rest would parse as HTML. \u003c is valid JSON and identical to a
+        // parser.
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(data).replace(/</g, '\\u003c'),
+        }}
       />
     </Head>
   );

--- a/components/head/publication-schema.jsx
+++ b/components/head/publication-schema.jsx
@@ -6,6 +6,7 @@ import { ALICE_ID, CABINET_ID } from './site-schema';
 
 import { plainText } from '../../libs/expertise';
 import { isPress } from '../../libs/publications';
+import { isSafeExternal } from '../../libs/href';
 import { expertiseSlugIn, withLocale } from '../../libs/localePath';
 import headerContent from '../../content/headerContent.json';
 
@@ -58,7 +59,8 @@ function PublicationSchema({ post, title, series }) {
           ...(post.author
             ? { author: { '@type': 'Organization', name: post.author } }
             : {}),
-          ...(post.source ? { sameAs: post.source } : {}),
+          // Gated like the anchor on the page: one decision about `source`.
+          ...(isSafeExternal(post.source) ? { sameAs: post.source } : {}),
         }
       : { author: { '@id': ALICE_ID }, publisher: { '@id': CABINET_ID } }),
     ...(fieldSlug

--- a/components/head/publication-schema.jsx
+++ b/components/head/publication-schema.jsx
@@ -46,12 +46,21 @@ function PublicationSchema({ post, title, series }) {
     inLanguage: locale,
     datePublished: post.publishedAt,
     dateModified: post.publishedAt,
-    publisher: { '@id': CABINET_ID },
     isAccessibleForFree: true,
     ...(series ? { isPartOf: { '@type': 'CreativeWorkSeries', name: series } } : {}),
+    // A press cutting is someone else's work: the outlet wrote and published
+    // it, and the practice is only mentioned in it. Naming the practice as the
+    // publisher asserted it published Le Monde's article; omitting the author
+    // entirely left a NewsArticle that no rich result will accept.
     ...(press
-      ? { mentions: { '@id': CABINET_ID }, ...(post.source ? { sameAs: post.source } : {}) }
-      : { author: { '@id': ALICE_ID } }),
+      ? {
+          mentions: { '@id': CABINET_ID },
+          ...(post.author
+            ? { author: { '@type': 'Organization', name: post.author } }
+            : {}),
+          ...(post.source ? { sameAs: post.source } : {}),
+        }
+      : { author: { '@id': ALICE_ID }, publisher: { '@id': CABINET_ID } }),
     ...(fieldSlug
       ? {
           about: {

--- a/components/head/publication-schema.jsx
+++ b/components/head/publication-schema.jsx
@@ -20,7 +20,7 @@ const localeUrl = (locale, path) => `${HOST}${withLocale(locale, path)}`;
 function PublicationSchema({ post, title, series }) {
   const { locale } = useRouter();
   const nav = (headerContent[locale] ?? headerContent.fr).nav;
-  const label = url => nav.find(link => link.url === url)?.label;
+  const label = path => nav.find(link => link.url === path)?.label;
 
   const url = localeUrl(locale, `/publications/${post.slug}`);
   const press = isPress(post);

--- a/components/head/publication-schema.jsx
+++ b/components/head/publication-schema.jsx
@@ -1,0 +1,82 @@
+import { useRouter } from 'next/router';
+
+import JsonLd from './json-ld';
+import { HOST } from './head-page';
+import { CABINET_ID } from './site-schema';
+
+import { expertiseSlug, plainText } from '../../libs/expertise';
+import { withLocale } from '../../libs/localePath';
+import headerContent from '../../content/headerContent.json';
+
+const ALICE_ID = `${HOST}/#alice`;
+
+const localeUrl = (locale, path) => `${HOST}${withLocale(locale, path)}`;
+
+// An article by a named lawyer, about a named practice area, published by the
+// practice. All three already exist as nodes in the site graph, so this attaches
+// to them by `@id` rather than restating them.
+//
+// A press cutting is someone else's work: it is marked up as the practice being
+// mentioned, not as something the practice wrote.
+function PublicationSchema({ post, title, series }) {
+  const { locale } = useRouter();
+  const nav = (headerContent[locale] ?? headerContent.fr).nav;
+  const label = url => nav.find(link => link.url === url)?.label;
+
+  const url = localeUrl(locale, `/publications/${post.slug}`);
+  const isPress = post.filter === 'press';
+
+  const crumb = (name, path, position) => ({
+    '@type': 'ListItem',
+    position,
+    name,
+    item: localeUrl(locale, path),
+  });
+
+  const article = {
+    '@type': isPress ? 'NewsArticle' : 'Article',
+    '@id': `${url}#article`,
+    headline: title,
+    name: post.title,
+    description: plainText(post.body, 300),
+    url,
+    inLanguage: locale,
+    datePublished: post.publishedAt,
+    dateModified: post.publishedAt,
+    publisher: { '@id': CABINET_ID },
+    isAccessibleForFree: true,
+    ...(series ? { isPartOf: { '@type': 'CreativeWorkSeries', name: series } } : {}),
+    ...(isPress
+      ? { mentions: { '@id': CABINET_ID }, ...(post.source ? { sameAs: post.source } : {}) }
+      : { author: { '@id': ALICE_ID } }),
+    ...(post.field
+      ? {
+          about: {
+            '@id': `${localeUrl(
+              locale,
+              `/expertise/${expertiseSlug(post.field)}`
+            )}#service`,
+          },
+        }
+      : {}),
+  };
+
+  const data = {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          crumb(label('/') ?? 'Accueil', '/', 1),
+          crumb(label('/publications') ?? 'Publications', '/publications', 2),
+          crumb(title, `/publications/${post.slug}`, 3),
+        ],
+      },
+      article,
+    ],
+  };
+
+  return <JsonLd id='publication-schema' data={data} />;
+}
+
+export default PublicationSchema;

--- a/components/head/publication-schema.jsx
+++ b/components/head/publication-schema.jsx
@@ -2,14 +2,12 @@ import { useRouter } from 'next/router';
 
 import JsonLd from './json-ld';
 import { HOST } from './head-page';
-import { CABINET_ID } from './site-schema';
+import { ALICE_ID, CABINET_ID } from './site-schema';
 
-import { expertiseSlug, plainText } from '../../libs/expertise';
+import { plainText } from '../../libs/expertise';
 import { isPress } from '../../libs/publications';
-import { withLocale } from '../../libs/localePath';
+import { expertiseSlugIn, withLocale } from '../../libs/localePath';
 import headerContent from '../../content/headerContent.json';
-
-const ALICE_ID = `${HOST}/#alice`;
 
 const localeUrl = (locale, path) => `${HOST}${withLocale(locale, path)}`;
 
@@ -26,6 +24,10 @@ function PublicationSchema({ post, title, series }) {
 
   const url = localeUrl(locale, `/publications/${post.slug}`);
   const press = isPress(post);
+
+  // Same single-locale reference the on-page link resolves: pointing `about` at
+  // the other language's slug would leave a dangling @id in the graph.
+  const fieldSlug = expertiseSlugIn(post.field, locale);
 
   const crumb = (name, path, position) => ({
     '@type': 'ListItem',
@@ -50,13 +52,10 @@ function PublicationSchema({ post, title, series }) {
     ...(press
       ? { mentions: { '@id': CABINET_ID }, ...(post.source ? { sameAs: post.source } : {}) }
       : { author: { '@id': ALICE_ID } }),
-    ...(post.field
+    ...(fieldSlug
       ? {
           about: {
-            '@id': `${localeUrl(
-              locale,
-              `/expertise/${expertiseSlug(post.field)}`
-            )}#service`,
+            '@id': `${localeUrl(locale, `/expertise/${fieldSlug}`)}#service`,
           },
         }
       : {}),

--- a/components/head/publication-schema.jsx
+++ b/components/head/publication-schema.jsx
@@ -5,6 +5,7 @@ import { HOST } from './head-page';
 import { CABINET_ID } from './site-schema';
 
 import { expertiseSlug, plainText } from '../../libs/expertise';
+import { isPress } from '../../libs/publications';
 import { withLocale } from '../../libs/localePath';
 import headerContent from '../../content/headerContent.json';
 
@@ -24,7 +25,7 @@ function PublicationSchema({ post, title, series }) {
   const label = url => nav.find(link => link.url === url)?.label;
 
   const url = localeUrl(locale, `/publications/${post.slug}`);
-  const isPress = post.filter === 'press';
+  const press = isPress(post);
 
   const crumb = (name, path, position) => ({
     '@type': 'ListItem',
@@ -34,7 +35,7 @@ function PublicationSchema({ post, title, series }) {
   });
 
   const article = {
-    '@type': isPress ? 'NewsArticle' : 'Article',
+    '@type': press ? 'NewsArticle' : 'Article',
     '@id': `${url}#article`,
     headline: title,
     name: post.title,
@@ -46,7 +47,7 @@ function PublicationSchema({ post, title, series }) {
     publisher: { '@id': CABINET_ID },
     isAccessibleForFree: true,
     ...(series ? { isPartOf: { '@type': 'CreativeWorkSeries', name: series } } : {}),
-    ...(isPress
+    ...(press
       ? { mentions: { '@id': CABINET_ID }, ...(post.source ? { sameAs: post.source } : {}) }
       : { author: { '@id': ALICE_ID } }),
     ...(post.field

--- a/components/head/site-schema.jsx
+++ b/components/head/site-schema.jsx
@@ -16,8 +16,9 @@ const ALICE_ID = `${HOST}/#alice`;
 // `@graph` rather than three scripts, so the nodes can reference each other by
 // `@id` and Google resolves one entity instead of three loose ones.
 //
-// No `geo` block: the coordinates the site still carries point at the previous
-// office, and a wrong latitude is worse than no latitude.
+// The coordinates and the map link come from the live Google listing for the
+// business, not from the stale ones the site used to carry, so `geo` states the
+// same point Google already holds.
 function SiteSchema() {
   const { locale } = useRouter();
   const org = organizationContent[locale] ?? organizationContent.fr;
@@ -35,6 +36,8 @@ function SiteSchema() {
         telephone: footerContent.phone,
         email,
         address: { '@type': 'PostalAddress', ...footerContent.postalAddress },
+        geo: { '@type': 'GeoCoordinates', ...footerContent.geo },
+        hasMap: footerContent.mapsUrl,
         areaServed: { '@type': 'City', name: org.areaServed },
         availableLanguage: ['fr', 'en'],
         founder: { '@id': ALICE_ID },
@@ -44,6 +47,7 @@ function SiteSchema() {
           name: 'ISKA Avocats',
           url: ISKA_URL,
         },
+        sameAs: [footerContent.mapsUrl],
       },
       {
         '@type': 'Person',

--- a/components/head/site-schema.jsx
+++ b/components/head/site-schema.jsx
@@ -10,7 +10,7 @@ const ISKA_URL = 'https://www.iska-avocats.fr';
 const LINKEDIN_URL = 'https://fr.linkedin.com/in/alice-ouaknine-23a4186b';
 
 export const CABINET_ID = `${HOST}/#cabinet`;
-const ALICE_ID = `${HOST}/#alice`;
+export const ALICE_ID = `${HOST}/#alice`;
 
 // The practice's identity, published once per page from the layout. A single
 // `@graph` rather than three scripts, so the nodes can reference each other by

--- a/components/layout/footer/main-footer.jsx
+++ b/components/layout/footer/main-footer.jsx
@@ -65,7 +65,7 @@ function MainFooter() {
             />
           </a>
           <a
-            href='https://www.google.com/maps/place/Ouaknine+Alice+Avocat/@48.8775684,2.3168902,15z/data=!4m5!3m4!1s0x0:0x51a276d4dfa05806!8m2!3d48.8775684!4d2.3168902'
+            href={CONTENT.mapsUrl}
             target='_blank'
             rel='noreferrer'
             alt='Google Alice Ouaknine'

--- a/components/layout/navbar/language-picker-mobile.jsx
+++ b/components/layout/navbar/language-picker-mobile.jsx
@@ -1,12 +1,14 @@
 import classes from './language-picker-mobile.module.scss';
 import useLocale from '../../../hooks/useLocale';
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import localePath from '../../../libs/localePath';
+import { LocalesContextSchema } from '../../../context/locales-context';
 
 function LanguagePickerMobile(props) {
   const locale = useLocale();
   const router = useRouter();
+  const availableLocales = useContext(LocalesContextSchema);
   const [state, setState] = useState(locale);
 
   const { pathname, asPath, query } = router;
@@ -18,7 +20,7 @@ function LanguagePickerMobile(props) {
   // the other language has to be asked for by hand.
   useEffect(() => {
     // router.prefetch only takes a string, unlike router.push below.
-    const target = localePath(router, other);
+    const target = localePath(router, other, availableLocales);
     router.prefetch(typeof target === 'string' ? target : pathname, undefined, {
       locale: other,
     });
@@ -27,7 +29,7 @@ function LanguagePickerMobile(props) {
 
   const toggleHandler = loc => {
     setState(l => loc);
-    const target = localePath(router, loc);
+    const target = localePath(router, loc, availableLocales);
 
     router.push(target, typeof target === 'string' ? undefined : asPath, {
       locale: loc,

--- a/components/layout/navbar/language-picker.jsx
+++ b/components/layout/navbar/language-picker.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useContext } from 'react';
 import useClickOutside from '../../../hooks/useClickoutside';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
@@ -9,6 +9,7 @@ import {
 
 import useLocale from '../../../hooks/useLocale';
 import localePath from '../../../libs/localePath';
+import { LocalesContextSchema } from '../../../context/locales-context';
 
 import classes from './language-picker.module.scss';
 
@@ -16,6 +17,7 @@ function LanguagePicker() {
   const [state, setState] = useState(false);
   const locale = useLocale();
   const router = useRouter();
+  const availableLocales = useContext(LocalesContextSchema);
   const dropdown = useRef();
   const capLocale = locale.charAt(0).toUpperCase() + locale.slice(1);
 
@@ -38,7 +40,7 @@ function LanguagePicker() {
         />
       </div>
       <div className={`${classes.selector} ${state && classes.selectoractive}`}>
-        <Link locale='fr' href={localePath(router, 'fr')}>
+        <Link locale='fr' href={localePath(router, 'fr', availableLocales)}>
           <a className={classes.label}>
             <CheckIcon
               className={`${classes.check} ${
@@ -49,7 +51,7 @@ function LanguagePicker() {
           </a>
         </Link>
 
-        <Link locale='en' href={localePath(router, 'en')}>
+        <Link locale='en' href={localePath(router, 'en', availableLocales)}>
           <a className={classes.label}>
             <CheckIcon
               className={`${classes.check} ${

--- a/components/layout/publication-page.jsx
+++ b/components/layout/publication-page.jsx
@@ -5,21 +5,14 @@ import PublicationSchema from '../head/publication-schema';
 import PageTitle from './page-title';
 import RichText from '../ui/rich-text';
 
-import { isPress, splitTitle } from '../../libs/publications';
-import { expertiseSlug } from '../../libs/expertise';
+import { formatDate, isPress, splitTitle } from '../../libs/publications';
+import { expertiseSlugIn } from '../../libs/localePath';
 import useLocale from '../../hooks/useLocale';
 import CONTENT from '../../content/publicationsContent.json';
 
 import classes from './publication-page.module.scss';
 
 const pad = n => String(n).padStart(2, '0');
-
-const formatDate = (iso, locale) =>
-  new Date(iso).toLocaleDateString(locale === 'en' ? 'en-GB' : 'fr-FR', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  });
 
 // The guide's own cross-links, as navigation rather than as prose. The rail is
 // the one from the fields of expertise: a sticky index of no height, so it stays
@@ -51,6 +44,11 @@ function PublicationPage({ post, series, seo }) {
   const copy = CONTENT[locale] ?? CONTENT.fr;
   const { series: seriesName, episode, title } = splitTitle(post);
 
+  // relatedExpertise points at one language's document. Under the other locale
+  // the derived slug names a page that is not served, so the link is resolved
+  // through the pairs and dropped when the field has no counterpart.
+  const fieldSlug = expertiseSlugIn(post.field, locale);
+
   const position = series?.findIndex(e => e.post._id === post._id) ?? -1;
   const previous = position > 0 ? series[position - 1] : null;
   const next =
@@ -67,15 +65,19 @@ function PublicationPage({ post, series, seo }) {
         </span>
       )}
       <span className={classes.metaitem}>
-        {formatDate(post.publishedAt, locale)}
+        {formatDate(post.publishedAt, locale, {
+          year: 'numeric',
+          month: 'long',
+          day: 'numeric',
+        })}
       </span>
       {post.readingTime > 0 && (
         <span className={classes.metaitem}>
           {post.readingTime} {copy.readingTime}
         </span>
       )}
-      {post.field && (
-        <Link href={`/expertise/${expertiseSlug(post.field)}`}>
+      {fieldSlug && (
+        <Link href={`/expertise/${fieldSlug}`}>
           <a className={classes.metalink}>{post.field}</a>
         </Link>
       )}
@@ -95,13 +97,11 @@ function PublicationPage({ post, series, seo }) {
 
       <div className={classes.container}>
         <div className={classes.layout}>
-          <SeriesRail series={series} current={post._id} copy={copy} />
-
           <article className={classes.article}>
             {meta}
 
             <div className={classes.body}>
-              <RichText value={post.body} />
+              <RichText value={post.body} headingLevel='h2' />
             </div>
 
             {post.source && (
@@ -152,6 +152,8 @@ function PublicationPage({ post, series, seo }) {
               <a className={classes.back}>{copy.backToIndex}</a>
             </Link>
           </article>
+
+          <SeriesRail series={series} current={post._id} copy={copy} />
         </div>
       </div>
     </div>

--- a/components/layout/publication-page.jsx
+++ b/components/layout/publication-page.jsx
@@ -5,7 +5,7 @@ import PublicationSchema from '../head/publication-schema';
 import PageTitle from './page-title';
 import RichText from '../ui/rich-text';
 
-import { splitTitle } from '../../libs/publications';
+import { isPress, splitTitle } from '../../libs/publications';
 import { expertiseSlug } from '../../libs/expertise';
 import useLocale from '../../hooks/useLocale';
 import CONTENT from '../../content/publicationsContent.json';
@@ -111,7 +111,7 @@ function PublicationPage({ post, series, seo }) {
               </a>
             )}
 
-            {post.filter !== 'press' && post.author && (
+            {!isPress(post) && post.author && (
               <div className={classes.author}>
                 <span className={classes.authorlabel}>{copy.author}</span>
                 <span className={classes.authorname}>{post.author}</span>

--- a/components/layout/publication-page.jsx
+++ b/components/layout/publication-page.jsx
@@ -95,14 +95,10 @@ function PublicationPage({ post, series, seo }) {
 
       <div className={classes.container}>
         <div className={classes.layout}>
-          {series?.length ? (
-            <SeriesRail series={series} current={post._id} copy={copy} />
-          ) : (
-            <div className={classes.gutter}>{meta}</div>
-          )}
+          <SeriesRail series={series} current={post._id} copy={copy} />
 
           <article className={classes.article}>
-            {series?.length ? meta : null}
+            {meta}
 
             <div className={classes.body}>
               <RichText value={post.body} />

--- a/components/layout/publication-page.jsx
+++ b/components/layout/publication-page.jsx
@@ -6,6 +6,7 @@ import PageTitle from './page-title';
 import RichText from '../ui/rich-text';
 
 import { formatDate, isPress, splitTitle } from '../../libs/publications';
+import { isSafeExternal } from '../../libs/href';
 import { expertiseSlugIn } from '../../libs/localePath';
 import useLocale from '../../hooks/useLocale';
 import CONTENT from '../../content/publicationsContent.json';
@@ -106,7 +107,7 @@ function PublicationPage({ post, series, seo }) {
               <RichText value={post.body} headingLevel='h2' />
             </div>
 
-            {post.source && (
+            {isSafeExternal(post.source) && (
               <a
                 className={classes.source}
                 href={post.source}

--- a/components/layout/publication-page.jsx
+++ b/components/layout/publication-page.jsx
@@ -58,6 +58,30 @@ function PublicationPage({ post, series, seo }) {
       ? series[position + 1]
       : null;
 
+  const meta = (
+    <div className={classes.meta}>
+      {seriesName && (
+        <span className={classes.metaitem}>
+          {seriesName}
+          {episode ? ` — ${copy.episode} ${episode}` : ''}
+        </span>
+      )}
+      <span className={classes.metaitem}>
+        {formatDate(post.publishedAt, locale)}
+      </span>
+      {post.readingTime > 0 && (
+        <span className={classes.metaitem}>
+          {post.readingTime} {copy.readingTime}
+        </span>
+      )}
+      {post.field && (
+        <Link href={`/expertise/${expertiseSlug(post.field)}`}>
+          <a className={classes.metalink}>{post.field}</a>
+        </Link>
+      )}
+    </div>
+  );
+
   return (
     <div>
       <HeadPage
@@ -71,30 +95,14 @@ function PublicationPage({ post, series, seo }) {
 
       <div className={classes.container}>
         <div className={classes.layout}>
-          <SeriesRail series={series} current={post._id} copy={copy} />
+          {series?.length ? (
+            <SeriesRail series={series} current={post._id} copy={copy} />
+          ) : (
+            <div className={classes.gutter}>{meta}</div>
+          )}
 
           <article className={classes.article}>
-            <div className={classes.meta}>
-              {seriesName && (
-                <span className={classes.metaitem}>
-                  {seriesName}
-                  {episode ? ` — ${copy.episode} ${episode}` : ''}
-                </span>
-              )}
-              <span className={classes.metaitem}>
-                {formatDate(post.publishedAt, locale)}
-              </span>
-              {post.readingTime > 0 && (
-                <span className={classes.metaitem}>
-                  {post.readingTime} {copy.readingTime}
-                </span>
-              )}
-              {post.field && (
-                <Link href={`/expertise/${expertiseSlug(post.field)}`}>
-                  <a className={classes.metalink}>{post.field}</a>
-                </Link>
-              )}
-            </div>
+            {series?.length ? meta : null}
 
             <div className={classes.body}>
               <RichText value={post.body} />

--- a/components/layout/publication-page.jsx
+++ b/components/layout/publication-page.jsx
@@ -29,7 +29,11 @@ function SeriesRail({ series, current, copy }) {
               className={classes.railitem}
               aria-current={post._id === current ? 'page' : undefined}
             >
-              <span className={classes.railindex}>{pad(episode ?? 0)}</span>
+              {episode ? (
+                <span className={classes.railindex}>{pad(episode)}</span>
+              ) : (
+                <span />
+              )}
               <span className={classes.railtitle}>{title}</span>
             </a>
           </Link>
@@ -49,12 +53,10 @@ function PublicationPage({ post, series, seo }) {
   // through the pairs and dropped when the field has no counterpart.
   const fieldSlug = expertiseSlugIn(post.field, locale);
 
-  const position = series?.findIndex(e => e.post._id === post._id) ?? -1;
+  const position = series ? series.findIndex(e => e.post._id === post._id) : -1;
   const previous = position > 0 ? series[position - 1] : null;
-  const next =
-    position >= 0 && position < (series?.length ?? 0) - 1
-      ? series[position + 1]
-      : null;
+  // The guard has to stay: at -1, series[0] would wrongly be the next episode.
+  const next = position >= 0 ? series[position + 1] ?? null : null;
 
   const meta = (
     <div className={classes.meta}>

--- a/components/layout/publication-page.jsx
+++ b/components/layout/publication-page.jsx
@@ -1,0 +1,157 @@
+import Link from 'next/link';
+
+import HeadPage from '../head/head-page';
+import PublicationSchema from '../head/publication-schema';
+import PageTitle from './page-title';
+import RichText from '../ui/rich-text';
+
+import { splitTitle } from '../../libs/publications';
+import { expertiseSlug } from '../../libs/expertise';
+import useLocale from '../../hooks/useLocale';
+import CONTENT from '../../content/publicationsContent.json';
+
+import classes from './publication-page.module.scss';
+
+const pad = n => String(n).padStart(2, '0');
+
+const formatDate = (iso, locale) =>
+  new Date(iso).toLocaleDateString(locale === 'en' ? 'en-GB' : 'fr-FR', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+
+// The guide's own cross-links, as navigation rather than as prose. The rail is
+// the one from the fields of expertise: a sticky index of no height, so it stays
+// pinned for the whole of the article instead of being pushed by the footer.
+function SeriesRail({ series, current, copy }) {
+  if (!series?.length) return null;
+
+  return (
+    <nav className={classes.rail} aria-label={copy.series}>
+      <div className={classes.railinner}>
+        {series.map(({ post, episode, title }) => (
+          <Link key={post._id} href={`/publications/${post.slug}`}>
+            <a
+              className={classes.railitem}
+              aria-current={post._id === current ? 'page' : undefined}
+            >
+              <span className={classes.railindex}>{pad(episode ?? 0)}</span>
+              <span className={classes.railtitle}>{title}</span>
+            </a>
+          </Link>
+        ))}
+      </div>
+    </nav>
+  );
+}
+
+function PublicationPage({ post, series, seo }) {
+  const locale = useLocale();
+  const copy = CONTENT[locale] ?? CONTENT.fr;
+  const { series: seriesName, episode, title } = splitTitle(post);
+
+  const position = series?.findIndex(e => e.post._id === post._id) ?? -1;
+  const previous = position > 0 ? series[position - 1] : null;
+  const next =
+    position >= 0 && position < (series?.length ?? 0) - 1
+      ? series[position + 1]
+      : null;
+
+  return (
+    <div>
+      <HeadPage
+        title={seo?.title ?? ''}
+        description={seo?.description ?? ''}
+        alternatePaths={seo?.alternates}
+      />
+      <PublicationSchema post={post} title={title} series={seriesName} />
+
+      <PageTitle title={title} />
+
+      <div className={classes.container}>
+        <div className={classes.layout}>
+          <SeriesRail series={series} current={post._id} copy={copy} />
+
+          <article className={classes.article}>
+            <div className={classes.meta}>
+              {seriesName && (
+                <span className={classes.metaitem}>
+                  {seriesName}
+                  {episode ? ` — ${copy.episode} ${episode}` : ''}
+                </span>
+              )}
+              <span className={classes.metaitem}>
+                {formatDate(post.publishedAt, locale)}
+              </span>
+              {post.readingTime > 0 && (
+                <span className={classes.metaitem}>
+                  {post.readingTime} {copy.readingTime}
+                </span>
+              )}
+              {post.field && (
+                <Link href={`/expertise/${expertiseSlug(post.field)}`}>
+                  <a className={classes.metalink}>{post.field}</a>
+                </Link>
+              )}
+            </div>
+
+            <div className={classes.body}>
+              <RichText value={post.body} />
+            </div>
+
+            {post.source && (
+              <a
+                className={classes.source}
+                href={post.source}
+                target='_blank'
+                rel='noreferrer noopener'
+              >
+                {copy.source}
+              </a>
+            )}
+
+            {post.filter !== 'press' && post.author && (
+              <div className={classes.author}>
+                <span className={classes.authorlabel}>{copy.author}</span>
+                <span className={classes.authorname}>{post.author}</span>
+                <span className={classes.authorrole}>{copy.authorRole}</span>
+              </div>
+            )}
+
+            {(previous || next) && (
+              <div className={classes.pager}>
+                {previous ? (
+                  <Link href={`/publications/${previous.post.slug}`}>
+                    <a className={classes.pagerlink}>
+                      <span className={classes.pagerlabel}>{copy.previous}</span>
+                      <span className={classes.pagertitle}>
+                        {previous.title}
+                      </span>
+                    </a>
+                  </Link>
+                ) : (
+                  <span />
+                )}
+                {next && (
+                  <Link href={`/publications/${next.post.slug}`}>
+                    <a className={`${classes.pagerlink} ${classes.pagernext}`}>
+                      <span className={classes.pagerlabel}>{copy.next}</span>
+                      <span className={classes.pagertitle}>{next.title}</span>
+                    </a>
+                  </Link>
+                )}
+              </div>
+            )}
+
+            <Link href='/publications'>
+              <a className={classes.back}>{copy.backToIndex}</a>
+            </Link>
+          </article>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default PublicationPage;

--- a/components/layout/publication-page.module.scss
+++ b/components/layout/publication-page.module.scss
@@ -79,20 +79,18 @@
   transition: color $dur $ease;
 }
 
+// The left column always carries something: the series index on a guide
+// episode, the article's own meta on anything else. An article outside a guide
+// has no series to index, and its own headings would not do the job either
+// (many are too short to have any worth listing), but every article has a date,
+// a length and a field. Body copy is 62ch on both page types, so the two now
+// set text at the same width in the same place.
+.gutter {
+  padding-top: $space-1;
+}
+
 .article {
   min-width: 0;
-
-  // An article outside a guide has no rail, so it is the only thing in the row.
-  // Left to auto-placement it lands in the 17rem index column and sets its text
-  // at a quarter of the width, so it takes the whole row instead.
-  //
-  // Capped at the measure with it: body copy stops at 62ch either way, and a
-  // row of hairlines running on for another 600px past the last word reads as
-  // text that failed to fill rather than as a column.
-  &:only-child {
-    grid-column: 1 / -1;
-    max-width: $measure;
-  }
 }
 
 .meta {
@@ -101,6 +99,15 @@
   gap: $space-1 $space-3;
   padding-bottom: $space-3;
   @include borderbottomlight;
+}
+
+// In the gutter it is a stack rather than a row, and the rule above it lines up
+// with the one the index carries on a guide episode.
+.gutter .meta {
+  flex-direction: column;
+  gap: $space-1;
+  padding: $space-2 0 $space-3 0;
+  @include bordertoplight;
 }
 
 .metaitem {
@@ -130,6 +137,12 @@
   // is: the guide uses h4 throughout, a press cutting opens on the outlet's own
   // h2. Left to the global rule that h2 renders as a 40px Didone, which fights
   // the page banner directly beneath it.
+  // The container already opens the gap under the meta rule; the first block
+  // adding its own on top of it leaves a hole the width of a paragraph.
+  > :first-child {
+    margin-top: 0;
+  }
+
   h2,
   h3,
   h4,
@@ -255,7 +268,13 @@
 
   // Stacked, the index would put five links between the title and the first
   // sentence. An article is read before it is navigated, so the rest of the
-  // guide goes underneath it, next to the pager.
+  // guide goes underneath it, next to the pager. The meta is not navigation and
+  // stays where it belongs, above the first line.
+  .gutter {
+    order: 0;
+    padding-top: 0;
+  }
+
   .article {
     order: 1;
   }

--- a/components/layout/publication-page.module.scss
+++ b/components/layout/publication-page.module.scss
@@ -1,0 +1,257 @@
+@use '../../styles/variables' as *;
+
+.container {
+  @include desktop-container;
+  padding: $space-6 0 $space-7 0;
+}
+
+// Same two-column shape as a field of expertise: a sticky index on the left,
+// the long text beside it. An article with no series drops the rail and the
+// text takes the row on its own.
+.layout {
+  display: grid;
+  grid-template-columns: minmax(0, 17rem) minmax(0, 1fr);
+  column-gap: $space-7;
+  align-items: start;
+}
+
+.rail {
+  // A sticky box gets pushed up once its own bottom edge reaches the bottom of
+  // its containing block. Sticking a box of no height and letting the index
+  // overflow it keeps the index pinned for the whole of the article.
+  position: sticky;
+  top: $space-7;
+  height: 0;
+}
+
+.railinner {
+  display: flex;
+  flex-direction: column;
+  @include bordertoplight;
+}
+
+.railitem {
+  position: relative;
+  display: grid;
+  grid-template-columns: 2.5rem minmax(0, 1fr);
+  align-items: baseline;
+  padding: $space-1 0;
+  @include borderbottomlight;
+
+  &::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    bottom: -1px;
+    height: 1px;
+    width: 100%;
+    background-color: $ink;
+    transform: scaleX(0);
+    transform-origin: left;
+    transition: transform $dur $ease;
+  }
+
+  &:hover::after,
+  &[aria-current='page']::after {
+    transform: scaleX(1);
+  }
+
+  &:hover,
+  &[aria-current='page'] {
+    .railindex,
+    .railtitle {
+      color: $ink;
+    }
+  }
+}
+
+.railindex {
+  @include micro;
+  color: $rule-strong;
+  transition: color $dur $ease;
+}
+
+.railtitle {
+  @include micro;
+  letter-spacing: 0.1em;
+  line-height: 1.5;
+  color: $ink-muted;
+  transition: color $dur $ease;
+}
+
+.article {
+  min-width: 0;
+}
+
+.meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $space-1 $space-3;
+  padding-bottom: $space-3;
+  @include borderbottomlight;
+}
+
+.metaitem {
+  @include micro;
+  color: $ink-muted;
+}
+
+.metalink {
+  @include micro;
+  color: $ink;
+  text-decoration: underline;
+  text-underline-offset: 0.3em;
+  text-decoration-color: $rule-strong;
+  transition: text-decoration-color $dur-fast $ease;
+
+  &:hover {
+    text-decoration-color: $ink;
+  }
+}
+
+.body {
+  max-width: $measure;
+  margin-top: $space-5;
+
+  h4 {
+    margin-top: $space-5;
+    margin-bottom: $space-2;
+    font-size: $fs-h3;
+    line-height: $lh-heading;
+    text-transform: none;
+    letter-spacing: -0.005em;
+    color: $ink;
+  }
+
+  p {
+    color: $ink-muted;
+    line-height: 1.7;
+  }
+
+  strong {
+    color: $ink;
+    font-weight: 500;
+  }
+}
+
+.source,
+.back {
+  display: inline-block;
+  margin-top: $space-5;
+  @include micro;
+  text-decoration: underline;
+  text-underline-offset: 0.3em;
+  text-decoration-color: $rule-strong;
+  transition: text-decoration-color $dur-fast $ease;
+
+  &:hover {
+    text-decoration-color: $ink;
+  }
+}
+
+// Who wrote it and what they are admitted to. On a page of legal advice this is
+// the part a reader and a search engine both weigh.
+.author {
+  display: flex;
+  flex-direction: column;
+  gap: $space-1;
+  margin-top: $space-6;
+  padding-top: $space-3;
+  @include bordertoplight;
+  border-top-color: $rule-strong;
+}
+
+.authorlabel {
+  @include micro;
+  color: $ink-muted;
+}
+
+.authorname {
+  @include serif;
+  font-size: $fs-h3;
+  line-height: $lh-heading;
+  text-transform: uppercase;
+}
+
+.authorrole {
+  font-size: 0.9375rem;
+  color: $ink-muted;
+}
+
+.pager {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: $space-4;
+  margin-top: $space-6;
+  padding-top: $space-3;
+  @include bordertoplight;
+}
+
+.pagerlink {
+  display: flex;
+  flex-direction: column;
+  gap: $space-1;
+  color: $ink-muted;
+  transition: color $dur-fast $ease;
+
+  &:hover {
+    color: $ink;
+  }
+}
+
+.pagernext {
+  text-align: right;
+}
+
+.pagerlabel {
+  @include micro;
+  font-size: 0.6875rem;
+  color: $rule-strong;
+}
+
+.pagertitle {
+  font-size: 0.9375rem;
+  line-height: 1.5;
+}
+
+@media (max-width: $breakpoint-lg) {
+  .layout {
+    column-gap: $space-5;
+  }
+}
+
+@media (max-width: $breakpoint-md) {
+  .container {
+    padding: $space-5 0 $space-6 0;
+  }
+
+  .layout {
+    grid-template-columns: minmax(0, 1fr);
+    row-gap: $space-6;
+  }
+
+  // Stacked, the index would put five links between the title and the first
+  // sentence. An article is read before it is navigated, so the rest of the
+  // guide goes underneath it, next to the pager.
+  .article {
+    order: 1;
+  }
+
+  .rail {
+    order: 2;
+    position: static;
+    height: auto;
+  }
+
+  .railitem {
+    padding: $space-2 0;
+  }
+
+  .pager {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .pagernext {
+    text-align: left;
+  }
+}

--- a/components/layout/publication-page.module.scss
+++ b/components/layout/publication-page.module.scss
@@ -73,7 +73,9 @@
 
 .railindex {
   @include micro;
-  color: $rule-strong;
+  // $rule-strong is a hairline token; as text on $bg it measures 2.06:1 against
+  // a 4.5:1 minimum. Same call as .pagerlabel below.
+  color: $ink-muted;
   transition: color $dur $ease;
 }
 
@@ -160,8 +162,12 @@
     color: $ink;
   }
 
-  p {
-    color: $ink-muted;
+  // On the block, not on `p`: a list item is prose too, and colouring only
+  // paragraphs set every bullet at full paper strength beside them.
+  color: $ink-muted;
+
+  p,
+  li {
     line-height: 1.7;
   }
 

--- a/components/layout/publication-page.module.scss
+++ b/components/layout/publication-page.module.scss
@@ -16,6 +16,12 @@
 }
 
 .rail {
+  // Placed rather than ordered. The article comes first in the markup so the
+  // reading and tab order match what is on screen at every width; `order` would
+  // have put the rail first in the DOM and last on the page.
+  grid-column: 1;
+  grid-row: 1;
+
   // A sticky box gets pushed up once its own bottom edge reaches the bottom of
   // its containing block. Sticking a box of no height and letting the index
   // overflow it keeps the index pinned for the whole of the article.
@@ -80,6 +86,8 @@
 }
 
 .article {
+  grid-column: 2;
+  grid-row: 1;
   min-width: 0;
 
   // An article outside a guide has no index beside it, so it takes the row
@@ -135,6 +143,7 @@
     margin-top: 0;
   }
 
+  h1,
   h2,
   h3,
   h4,
@@ -199,8 +208,10 @@
 }
 
 .authorname {
-  @include serif;
+  // Not @include serif: this runs at 20-28px, and the two-family split puts
+  // Bodoni above ~40px only. The sibling index file makes the same call.
   font-size: $fs-h3;
+  font-weight: 500;
   line-height: $lh-heading;
   text-transform: uppercase;
 }
@@ -237,8 +248,10 @@
 
 .pagerlabel {
   @include micro;
+  // $rule-strong is a hairline token; as text on $bg it measures 2.06:1 against
+  // a 4.5:1 minimum, and declaring a colour here also stopped the label taking
+  // the parent's hover. Inheriting fixes both.
   font-size: 0.6875rem;
-  color: $rule-strong;
 }
 
 .pagertitle {
@@ -264,13 +277,16 @@
 
   // Stacked, the index would put five links between the title and the first
   // sentence. An article is read before it is navigated, so the rest of the
-  // guide goes underneath it, next to the pager.
+  // guide goes underneath it, next to the pager, which is also the order it
+  // already has in the markup.
   .article {
-    order: 1;
+    grid-column: 1;
+    grid-row: 1;
   }
 
   .rail {
-    order: 2;
+    grid-column: 1;
+    grid-row: 2;
     position: static;
     height: auto;
   }

--- a/components/layout/publication-page.module.scss
+++ b/components/layout/publication-page.module.scss
@@ -81,6 +81,14 @@
 
 .article {
   min-width: 0;
+
+  // An article outside a guide has no rail, so it is the only thing in the row.
+  // Left to auto-placement it lands in the 17rem index column and sets its text
+  // at a quarter of the width; it takes the whole row instead. `.body` still
+  // caps at the measure, so the line length does not change.
+  &:only-child {
+    grid-column: 1 / -1;
+  }
 }
 
 .meta {
@@ -113,10 +121,21 @@
   max-width: $measure;
   margin-top: $space-5;
 
-  h4 {
+  // One heading treatment for every level. A piece of this length wants a
+  // single rank of headings, and the documents disagree about which tag that
+  // is: the guide uses h4 throughout, a press cutting opens on the outlet's own
+  // h2. Left to the global rule that h2 renders as a 40px Didone, which fights
+  // the page banner directly beneath it.
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
     margin-top: $space-5;
     margin-bottom: $space-2;
+    font-family: inherit;
     font-size: $fs-h3;
+    font-weight: 500;
     line-height: $lh-heading;
     text-transform: none;
     letter-spacing: -0.005em;

--- a/components/layout/publication-page.module.scss
+++ b/components/layout/publication-page.module.scss
@@ -79,18 +79,19 @@
   transition: color $dur $ease;
 }
 
-// The left column always carries something: the series index on a guide
-// episode, the article's own meta on anything else. An article outside a guide
-// has no series to index, and its own headings would not do the job either
-// (many are too short to have any worth listing), but every article has a date,
-// a length and a field. Body copy is 62ch on both page types, so the two now
-// set text at the same width in the same place.
-.gutter {
-  padding-top: $space-1;
-}
-
 .article {
   min-width: 0;
+
+  // An article outside a guide has no index beside it, so it takes the row
+  // rather than the 17rem column auto-placement would drop it into, and its
+  // text runs the full container instead of stopping at the measure.
+  &:only-child {
+    grid-column: 1 / -1;
+
+    .body {
+      max-width: none;
+    }
+  }
 }
 
 .meta {
@@ -99,15 +100,6 @@
   gap: $space-1 $space-3;
   padding-bottom: $space-3;
   @include borderbottomlight;
-}
-
-// In the gutter it is a stack rather than a row, and the rule above it lines up
-// with the one the index carries on a guide episode.
-.gutter .meta {
-  flex-direction: column;
-  gap: $space-1;
-  padding: $space-2 0 $space-3 0;
-  @include bordertoplight;
 }
 
 .metaitem {
@@ -170,9 +162,13 @@
   }
 }
 
+// Each on its own line. As inline-block siblings they ran together into
+// "Lire l'article d'origineToutes les publications", and `width: fit-content`
+// keeps the underline to the words rather than to the whole row.
 .source,
 .back {
-  display: inline-block;
+  display: block;
+  width: fit-content;
   margin-top: $space-5;
   @include micro;
   text-decoration: underline;
@@ -268,13 +264,7 @@
 
   // Stacked, the index would put five links between the title and the first
   // sentence. An article is read before it is navigated, so the rest of the
-  // guide goes underneath it, next to the pager. The meta is not navigation and
-  // stays where it belongs, above the first line.
-  .gutter {
-    order: 0;
-    padding-top: 0;
-  }
-
+  // guide goes underneath it, next to the pager.
   .article {
     order: 1;
   }

--- a/components/layout/publication-page.module.scss
+++ b/components/layout/publication-page.module.scss
@@ -175,6 +175,12 @@
     color: $ink;
     font-weight: 500;
   }
+
+  // The most emphasised block in a body would otherwise be the dimmest thing on
+  // the page, now that the muted colour sits on the block rather than on `p`.
+  blockquote {
+    color: $ink;
+  }
 }
 
 // Each on its own line. As inline-block siblings they ran together into

--- a/components/layout/publication-page.module.scss
+++ b/components/layout/publication-page.module.scss
@@ -84,10 +84,14 @@
 
   // An article outside a guide has no rail, so it is the only thing in the row.
   // Left to auto-placement it lands in the 17rem index column and sets its text
-  // at a quarter of the width; it takes the whole row instead. `.body` still
-  // caps at the measure, so the line length does not change.
+  // at a quarter of the width, so it takes the whole row instead.
+  //
+  // Capped at the measure with it: body copy stops at 62ch either way, and a
+  // row of hairlines running on for another 600px past the last word reads as
+  // text that failed to fill rather than as a column.
   &:only-child {
     grid-column: 1 / -1;
+    max-width: $measure;
   }
 }
 

--- a/components/layout/publications-index.jsx
+++ b/components/layout/publications-index.jsx
@@ -1,0 +1,123 @@
+import Link from 'next/link';
+
+import HeadPage from '../head/head-page';
+import PageTitle from './page-title';
+import { groupPublications, splitTitle } from '../../libs/publications';
+import useLocale from '../../hooks/useLocale';
+import CONTENT from '../../content/publicationsContent.json';
+
+import classes from './publications-index.module.scss';
+
+const pad = n => String(n).padStart(2, '0');
+
+const formatDate = (iso, locale) =>
+  new Date(iso).toLocaleDateString(locale === 'en' ? 'en-GB' : 'fr-FR', {
+    year: 'numeric',
+    month: 'long',
+  });
+
+// One row shape for everything on this page, the same one the home practice
+// list uses: a micro-caps number in the gutter, the title beside it, a hairline
+// beneath. An episode shows its number, an article its position in the list.
+function Row({ post, index, locale, copy }) {
+  const { title } = splitTitle(post);
+
+  return (
+    <li>
+      <Link href={`/publications/${post.slug}`}>
+        <a className={classes.row}>
+          <span className={classes.index}>{pad(index)}</span>
+          <span className={classes.value}>
+            <h3 className={classes.title}>{title}</h3>
+            <span className={classes.meta}>
+              {formatDate(post.publishedAt, locale)}
+              {post.filter === 'press' && post.author
+                ? ` — ${post.author}`
+                : post.readingTime
+                ? ` — ${post.readingTime} ${copy.readingTime}`
+                : ''}
+            </span>
+          </span>
+        </a>
+      </Link>
+    </li>
+  );
+}
+
+function Section({ label, children }) {
+  return (
+    <section className={classes.section}>
+      <h2 className={classes.sectiontitle}>{label}</h2>
+      {children}
+    </section>
+  );
+}
+
+function PublicationsIndex({ data, posts, seo }) {
+  const locale = useLocale();
+  const copy = CONTENT[locale] ?? CONTENT.fr;
+  const { guides, articles, press } = groupPublications(posts ?? []);
+
+  return (
+    <div>
+      <HeadPage title={seo?.title ?? ''} description={seo?.description ?? ''} />
+      <PageTitle title={data?.title ?? ''} />
+
+      <div className={classes.container}>
+        {guides.map(guide => (
+          <Section key={guide.series} label={guide.series}>
+            <ul className={classes.list}>
+              {guide.episodes.map((post, i) => (
+                <Row
+                  key={post._id}
+                  post={post}
+                  index={splitTitle(post).episode ?? i + 1}
+                  locale={locale}
+                  copy={copy}
+                />
+              ))}
+            </ul>
+          </Section>
+        ))}
+
+        {articles.length > 0 && (
+          <Section label={copy.articles}>
+            <ul className={classes.list}>
+              {articles.map((post, i) => (
+                <Row
+                  key={post._id}
+                  post={post}
+                  index={i + 1}
+                  locale={locale}
+                  copy={copy}
+                />
+              ))}
+            </ul>
+          </Section>
+        )}
+
+        {press.length > 0 && (
+          <Section label={copy.press}>
+            <ul className={classes.list}>
+              {press.map((post, i) => (
+                <Row
+                  key={post._id}
+                  post={post}
+                  index={i + 1}
+                  locale={locale}
+                  copy={copy}
+                />
+              ))}
+            </ul>
+          </Section>
+        )}
+
+        {guides.length === 0 && articles.length === 0 && press.length === 0 && (
+          <p className={classes.empty}>{copy.empty}</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default PublicationsIndex;

--- a/components/layout/publications-index.jsx
+++ b/components/layout/publications-index.jsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 
 import HeadPage from '../head/head-page';
 import PageTitle from './page-title';
-import { groupPublications, splitTitle } from '../../libs/publications';
+import { groupPublications, isPress, splitTitle } from '../../libs/publications';
 import useLocale from '../../hooks/useLocale';
 import CONTENT from '../../content/publicationsContent.json';
 
@@ -31,7 +31,7 @@ function Row({ post, index, locale, copy }) {
             <h3 className={classes.title}>{title}</h3>
             <span className={classes.meta}>
               {formatDate(post.publishedAt, locale)}
-              {post.filter === 'press' && post.author
+              {isPress(post) && post.author
                 ? ` — ${post.author}`
                 : post.readingTime
                 ? ` — ${post.readingTime} ${copy.readingTime}`

--- a/components/layout/publications-index.jsx
+++ b/components/layout/publications-index.jsx
@@ -2,19 +2,18 @@ import Link from 'next/link';
 
 import HeadPage from '../head/head-page';
 import PageTitle from './page-title';
-import { groupPublications, isPress, splitTitle } from '../../libs/publications';
+import {
+  formatDate,
+  groupPublications,
+  isPress,
+  splitTitle,
+} from '../../libs/publications';
 import useLocale from '../../hooks/useLocale';
 import CONTENT from '../../content/publicationsContent.json';
 
 import classes from './publications-index.module.scss';
 
 const pad = n => String(n).padStart(2, '0');
-
-const formatDate = (iso, locale) =>
-  new Date(iso).toLocaleDateString(locale === 'en' ? 'en-GB' : 'fr-FR', {
-    year: 'numeric',
-    month: 'long',
-  });
 
 // One row shape for everything on this page, the same one the home practice
 // list uses: a micro-caps number in the gutter, the title beside it, a hairline
@@ -30,7 +29,10 @@ function Row({ post, index, locale, copy }) {
           <span className={classes.value}>
             <h3 className={classes.title}>{title}</h3>
             <span className={classes.meta}>
-              {formatDate(post.publishedAt, locale)}
+              {formatDate(post.publishedAt, locale, {
+                year: 'numeric',
+                month: 'long',
+              })}
               {isPress(post) && post.author
                 ? ` — ${post.author}`
                 : post.readingTime

--- a/components/layout/publications-index.jsx
+++ b/components/layout/publications-index.jsx
@@ -46,11 +46,29 @@ function Row({ post, index, locale, copy }) {
   );
 }
 
-function Section({ label, children }) {
+// The three surfaces differ only in their heading and in where their row numbers
+// come from: a guide numbers by episode, the other two by position in the list.
+const byPosition = (post, index) => index + 1;
+
+const byEpisode = (post, index) => splitTitle(post).episode ?? index + 1;
+
+function Section({ label, posts, index = byPosition, locale, copy }) {
+  if (!posts.length) return null;
+
   return (
     <section className={classes.section}>
       <h2 className={classes.sectiontitle}>{label}</h2>
-      {children}
+      <ul className={classes.list}>
+        {posts.map((post, i) => (
+          <Row
+            key={post._id}
+            post={post}
+            index={index(post, i)}
+            locale={locale}
+            copy={copy}
+          />
+        ))}
+      </ul>
     </section>
   );
 }
@@ -67,52 +85,24 @@ function PublicationsIndex({ data, posts, seo }) {
 
       <div className={classes.container}>
         {guides.map(guide => (
-          <Section key={guide.series} label={guide.series}>
-            <ul className={classes.list}>
-              {guide.episodes.map((post, i) => (
-                <Row
-                  key={post._id}
-                  post={post}
-                  index={splitTitle(post).episode ?? i + 1}
-                  locale={locale}
-                  copy={copy}
-                />
-              ))}
-            </ul>
-          </Section>
+          <Section
+            key={guide.series}
+            label={guide.series}
+            posts={guide.episodes}
+            index={byEpisode}
+            locale={locale}
+            copy={copy}
+          />
         ))}
 
-        {articles.length > 0 && (
-          <Section label={copy.articles}>
-            <ul className={classes.list}>
-              {articles.map((post, i) => (
-                <Row
-                  key={post._id}
-                  post={post}
-                  index={i + 1}
-                  locale={locale}
-                  copy={copy}
-                />
-              ))}
-            </ul>
-          </Section>
-        )}
+        <Section
+          label={copy.articles}
+          posts={articles}
+          locale={locale}
+          copy={copy}
+        />
 
-        {press.length > 0 && (
-          <Section label={copy.press}>
-            <ul className={classes.list}>
-              {press.map((post, i) => (
-                <Row
-                  key={post._id}
-                  post={post}
-                  index={i + 1}
-                  locale={locale}
-                  copy={copy}
-                />
-              ))}
-            </ul>
-          </Section>
-        )}
+        <Section label={copy.press} posts={press} locale={locale} copy={copy} />
 
         {guides.length === 0 && articles.length === 0 && press.length === 0 && (
           <p className={classes.empty}>{copy.empty}</p>

--- a/components/layout/publications-index.module.scss
+++ b/components/layout/publications-index.module.scss
@@ -1,0 +1,124 @@
+@use '../../styles/variables' as *;
+
+@keyframes draw {
+  from {
+    clip-path: inset(0 100% 0 0);
+  }
+  to {
+    clip-path: inset(0 0 0 0);
+  }
+}
+
+.container {
+  @include desktop-container;
+  padding: $space-6 0 $space-7 0;
+}
+
+.section {
+  margin-bottom: $space-7;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+// A guide is named at section size in the display face; the episodes under it
+// stay at label size, which is the contrast the rest of the site is built on.
+.sectiontitle {
+  margin: 0 0 $space-4 0;
+  @include serif;
+  font-size: $fs-h2;
+  line-height: $lh-heading;
+  letter-spacing: -0.01em;
+  text-transform: uppercase;
+  text-wrap: balance;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  @include bordertoplight;
+}
+
+.row {
+  display: grid;
+  grid-template-columns: 3.5rem minmax(0, 1fr);
+  align-items: baseline;
+  gap: $space-4;
+  padding: $space-3 0;
+  color: $ink;
+  @include borderbottomlight;
+  transition: color $dur-fast $ease, border-color $dur-fast $ease;
+
+  animation: draw 500ms $ease both;
+
+  &:hover {
+    color: $paper-raised;
+    border-color: $rule-strong;
+
+    .index,
+    .meta {
+      color: $ink;
+    }
+  }
+}
+
+.index {
+  @include micro;
+  color: $ink-muted;
+  transition: color $dur-fast $ease;
+}
+
+.value {
+  display: flex;
+  flex-direction: column;
+  gap: $space-1;
+}
+
+.title {
+  margin: 0;
+  // An h3 for structure, a row label to read. The global heading rule would put
+  // Bodoni and uppercase on it, and a 17px Didone on black is where its
+  // hairlines go.
+  font-family: inherit;
+  text-transform: none;
+  font-size: 1.0625rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  line-height: $lh-heading;
+}
+
+.meta {
+  @include micro;
+  font-size: 0.6875rem;
+  color: $ink-muted;
+  transition: color $dur-fast $ease;
+}
+
+.empty {
+  color: $ink-muted;
+}
+
+@media (max-width: $breakpoint-md) {
+  .container {
+    padding: $space-5 0 $space-6 0;
+  }
+
+  .section {
+    margin-bottom: $space-6;
+  }
+
+  .row {
+    grid-template-columns: 2.5rem minmax(0, 1fr);
+    gap: $space-2;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .row {
+    animation: none;
+  }
+}

--- a/components/layout/publications-index.module.scss
+++ b/components/layout/publications-index.module.scss
@@ -53,7 +53,11 @@
   @include borderbottomlight;
   transition: color $dur-fast $ease, border-color $dur-fast $ease;
 
-  animation: draw 500ms $ease both;
+  // `backwards`, not `both`: `both` leaves the final `clip-path: inset(0 0 0 0)`
+  // applied for good, and a clip-path clips the whole rendering of the element,
+  // including the :focus-visible outline globals.scss draws outside its border
+  // box. Every row here is a link, so `both` means no keyboard focus ring.
+  animation: draw 500ms $ease backwards;
 
   &:hover {
     color: $paper-raised;

--- a/components/layout/publications-index.module.scss
+++ b/components/layout/publications-index.module.scss
@@ -14,7 +14,12 @@
   padding: $space-6 0 $space-7 0;
 }
 
+// globals.scss gives every `section` `padding: $space-7 0`, which stacked with
+// the margin below to separate two sections by ~18rem rather than the 6rem the
+// margin declares, and made the :last-child reset a no-op. The margin owns the
+// rhythm here.
 .section {
+  padding: 0;
   margin-bottom: $space-7;
 
   &:last-child {
@@ -84,10 +89,9 @@
 
 .title {
   margin: 0;
-  // An h3 for structure, a row label to read. The global heading rule would put
-  // Bodoni and uppercase on it, and a 17px Didone on black is where its
-  // hairlines go.
-  font-family: inherit;
+  // An h3 for structure, a row label to read. globals.scss sets h3 to uppercase
+  // Inter 600 at 1rem with 0.08em tracking; the overrides below are what make it
+  // a row label instead of a heading.
   text-transform: none;
   font-size: 1.0625rem;
   font-weight: 500;

--- a/components/ui/rich-text.jsx
+++ b/components/ui/rich-text.jsx
@@ -1,9 +1,26 @@
+import { createElement } from 'react';
 import Link from 'next/link';
 import { PortableText } from '@portabletext/react';
 import SanityImage from './sanityImage';
 import classes from './rich-text.module.scss';
 
-export default function RichText({ value }) {
+// `headingLevel` collapses every heading a document carries onto one tag. The
+// publications surface needs it: the guide writes h4 throughout and a press
+// cutting opens on the outlet's own h2, so without it the accessibility tree
+// exposes a gapped, inconsistent hierarchy under the page h1 while the stylesheet
+// renders them all alike.
+const headingOverrides = level =>
+  level
+    ? Object.fromEntries(
+        ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].map(style => [
+          style,
+          // eslint-disable-next-line react/display-name
+          ({ children }) => createElement(level, null, children),
+        ])
+      )
+    : {};
+
+export default function RichText({ value, headingLevel }) {
   return (
     <PortableText
       value={value}
@@ -11,6 +28,7 @@ export default function RichText({ value }) {
       }}
       components={{
         block: {
+          ...headingOverrides(headingLevel),
           // Ex. 1: customizing common block types
           normal: ({ children }) => {
             if (!children[0]) {
@@ -49,15 +67,23 @@ export default function RichText({ value }) {
           // link that leaves the site opens away from it.
           link: ({ children, value }) => {
             const href = value?.href || '/';
-            const isExternal = /^https?:\/\//i.test(href);
 
-            if (!isExternal) {
+            // An allowlist, not a scheme test. Treating "not http(s)" as
+            // internal handed `javascript:` and `data:` URLs straight to an
+            // anchor, and link marks are authored in the CMS.
+            const isInternal =
+              (href.startsWith('/') && !href.startsWith('//')) ||
+              href.startsWith('#');
+
+            if (isInternal) {
               return (
                 <Link href={href}>
                   <a className={classes.link}>{children}</a>
                 </Link>
               );
             }
+
+            if (!/^(https?|mailto|tel):/i.test(href)) return <>{children}</>;
 
             return (
               <a

--- a/components/ui/rich-text.jsx
+++ b/components/ui/rich-text.jsx
@@ -4,21 +4,46 @@ import { PortableText } from '@portabletext/react';
 import SanityImage from './sanityImage';
 import classes from './rich-text.module.scss';
 
+const SITE_HOST = 'ouaknine-avocats.com';
+
+// Where a link actually goes, resolved rather than pattern-matched.
+//
+// Two reasons not to test the raw string. The CMS authors internal links as
+// absolute URLs ("https://www.ouaknine-avocats.com/articles/<id>"), so a
+// startsWith('/') test sends every one of the guide's own cross-links out to a
+// new tab; and the URL parser strips tabs and treats a backslash as a slash, so
+// "/\evil.com" reads as a path and navigates off-site.
+//
+// Returns a same-origin path, or null when the link leaves the site.
+const internalPath = href => {
+  const clean = href.replace(/[\t\n\r]/g, '');
+  if (clean.startsWith('#')) return clean;
+
+  try {
+    const url = new URL(clean, 'https://internal.invalid');
+    const internal =
+      url.hostname === 'internal.invalid' ||
+      url.hostname === SITE_HOST ||
+      url.hostname.endsWith(`.${SITE_HOST}`);
+
+    return internal ? `${url.pathname}${url.search}${url.hash}` : null;
+  } catch (err) {
+    return null;
+  }
+};
+
 // `headingLevel` collapses every heading a document carries onto one tag. The
 // publications surface needs it: the guide writes h4 throughout and a press
 // cutting opens on the outlet's own h2, so without it the accessibility tree
 // exposes a gapped, inconsistent hierarchy under the page h1 while the stylesheet
 // renders them all alike.
-const headingOverrides = level =>
-  level
-    ? Object.fromEntries(
-        ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].map(style => [
-          style,
-          // eslint-disable-next-line react/display-name
-          ({ children }) => createElement(level, null, children),
-        ])
-      )
-    : {};
+const headingOverrides = level => {
+  if (!level) return {};
+
+  const Heading = ({ children }) => createElement(level, null, children);
+
+  return { h1: Heading, h2: Heading, h3: Heading, h4: Heading, h5: Heading, h6: Heading };
+};
 
 export default function RichText({ value, headingLevel }) {
   return (
@@ -67,23 +92,21 @@ export default function RichText({ value, headingLevel }) {
           // link that leaves the site opens away from it.
           link: ({ children, value }) => {
             const href = value?.href || '/';
+            const internal = internalPath(href);
 
-            // An allowlist, not a scheme test. Treating "not http(s)" as
-            // internal handed `javascript:` and `data:` URLs straight to an
-            // anchor, and link marks are authored in the CMS.
-            const isInternal =
-              (href.startsWith('/') && !href.startsWith('//')) ||
-              href.startsWith('#');
-
-            if (isInternal) {
+            if (internal) {
               return (
-                <Link href={href}>
+                <Link href={internal}>
                   <a className={classes.link}>{children}</a>
                 </Link>
               );
             }
 
-            if (!/^(https?|mailto|tel):/i.test(href)) return <>{children}</>;
+            // An allowlist, not a scheme denylist: anything that is not a
+            // recognised external scheme keeps its text and loses its link.
+            if (!/^(https?|mailto|tel):/i.test(href.trim())) {
+              return <>{children}</>;
+            }
 
             return (
               <a

--- a/components/ui/rich-text.jsx
+++ b/components/ui/rich-text.jsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { PortableText } from '@portabletext/react';
 import SanityImage from './sanityImage';
 import classes from './rich-text.module.scss';
@@ -43,16 +44,26 @@ export default function RichText({ value }) {
           ),
         },
         marks: {
+          // The guide cross-links its own episodes. Those are internal, and
+          // sending a reader to a new tab to read the next one is wrong; only a
+          // link that leaves the site opens away from it.
           link: ({ children, value }) => {
-            const rel = !value?.href?.startsWith('/')
-              ? 'noreferrer noopener'
-              : undefined;
+            const href = value?.href || '/';
+            const isExternal = /^https?:\/\//i.test(href);
+
+            if (!isExternal) {
+              return (
+                <Link href={href}>
+                  <a className={classes.link}>{children}</a>
+                </Link>
+              );
+            }
+
             return (
-              // eslint-disable-next-line react/jsx-no-target-blank
               <a
                 className={classes.link}
-                href={value?.href ? value.href : '/'}
-                rel={rel}
+                href={href}
+                rel='noreferrer noopener'
                 target='_blank'
               >
                 {children}

--- a/components/ui/rich-text.jsx
+++ b/components/ui/rich-text.jsx
@@ -1,36 +1,9 @@
 import { createElement } from 'react';
 import Link from 'next/link';
 import { PortableText } from '@portabletext/react';
+import { internalPath, isSafeExternal } from '../../libs/href';
 import SanityImage from './sanityImage';
 import classes from './rich-text.module.scss';
-
-const SITE_HOST = 'ouaknine-avocats.com';
-
-// Where a link actually goes, resolved rather than pattern-matched.
-//
-// Two reasons not to test the raw string. The CMS authors internal links as
-// absolute URLs ("https://www.ouaknine-avocats.com/articles/<id>"), so a
-// startsWith('/') test sends every one of the guide's own cross-links out to a
-// new tab; and the URL parser strips tabs and treats a backslash as a slash, so
-// "/\evil.com" reads as a path and navigates off-site.
-//
-// Returns a same-origin path, or null when the link leaves the site.
-const internalPath = href => {
-  const clean = href.replace(/[\t\n\r]/g, '');
-  if (clean.startsWith('#')) return clean;
-
-  try {
-    const url = new URL(clean, 'https://internal.invalid');
-    const internal =
-      url.hostname === 'internal.invalid' ||
-      url.hostname === SITE_HOST ||
-      url.hostname.endsWith(`.${SITE_HOST}`);
-
-    return internal ? `${url.pathname}${url.search}${url.hash}` : null;
-  } catch (err) {
-    return null;
-  }
-};
 
 // `headingLevel` collapses every heading a document carries onto one tag. The
 // publications surface needs it: the guide writes h4 throughout and a press
@@ -102,11 +75,7 @@ export default function RichText({ value, headingLevel }) {
               );
             }
 
-            // An allowlist, not a scheme denylist: anything that is not a
-            // recognised external scheme keeps its text and loses its link.
-            if (!/^(https?|mailto|tel):/i.test(href.trim())) {
-              return <>{children}</>;
-            }
+            if (!isSafeExternal(href)) return <>{children}</>;
 
             return (
               <a

--- a/content/500Content.json
+++ b/content/500Content.json
@@ -1,0 +1,8 @@
+{
+  "fr": {
+    "body": "Une erreur est survenue. Merci de réessayer dans un instant."
+  },
+  "en": {
+    "body": "Something went wrong. Please try again in a moment."
+  }
+}

--- a/content/footerContent.json
+++ b/content/footerContent.json
@@ -6,6 +6,8 @@
     "addressRegion": "Île-de-France",
     "addressCountry": "FR"
   },
+  "geo": { "latitude": 48.8816365, "longitude": 2.3346834 },
+  "mapsUrl": "https://www.google.com/maps/place/Ouaknine+Alice+Avocate/@48.8816365,2.3346834,17z/data=!4m6!3m5!1s0x47e67bc0f2a5e2bb:0x51a276d4dfa05806!8m2!3d48.8816365!4d2.3346834!16s%2Fg%2F11hfhpp1b7",
   "phone": "+33184162035",
   "mobilePhone": "+33629653512",
 

--- a/content/headerContent.json
+++ b/content/headerContent.json
@@ -3,6 +3,7 @@
     "nav": [
       { "label": "Le Cabinet", "url": "/" },
       { "label": "Expertise", "url": "/expertise" },
+      { "label": "Publications", "url": "/publications" },
       { "label": "Contact", "url": "/contact" }
     ],
     "iska": {
@@ -16,6 +17,7 @@
     "nav": [
       { "label": "The Firm", "url": "/" },
       { "label": "Expertise", "url": "/expertise" },
+      { "label": "Publications", "url": "/publications" },
       { "label": "Contact", "url": "/contact" }
     ],
     "iska": {

--- a/content/publicationsContent.json
+++ b/content/publicationsContent.json
@@ -1,5 +1,6 @@
 {
   "fr": {
+    "title": "Publications",
     "articles": "Articles",
     "press": "Le cabinet dans la presse",
     "episode": "Épisode",
@@ -14,6 +15,7 @@
     "empty": "Aucune publication pour le moment."
   },
   "en": {
+    "title": "Publications",
     "articles": "Articles",
     "press": "The firm in the press",
     "episode": "Episode",

--- a/content/publicationsContent.json
+++ b/content/publicationsContent.json
@@ -1,0 +1,36 @@
+{
+  "fr": {
+    "guides": "Guides",
+    "articles": "Articles",
+    "press": "Le cabinet dans la presse",
+    "episode": "Épisode",
+    "readingTime": "min de lecture",
+    "series": "Guide",
+    "field": "Domaine",
+    "author": "Écrit par",
+    "authorRole": "Avocate aux barreaux de Paris et de Californie",
+    "source": "Lire l'article d'origine",
+    "previous": "Épisode précédent",
+    "next": "Épisode suivant",
+    "backToIndex": "Toutes les publications",
+    "relatedExpertise": "Voir le champ de compétence",
+    "empty": "Aucune publication pour le moment."
+  },
+  "en": {
+    "guides": "Guides",
+    "articles": "Articles",
+    "press": "The firm in the press",
+    "episode": "Episode",
+    "readingTime": "min read",
+    "series": "Guide",
+    "field": "Practice area",
+    "author": "Written by",
+    "authorRole": "Attorney at the Paris and California bars",
+    "source": "Read the original article",
+    "previous": "Previous episode",
+    "next": "Next episode",
+    "backToIndex": "All publications",
+    "relatedExpertise": "See the practice area",
+    "empty": "No publications yet."
+  }
+}

--- a/content/publicationsContent.json
+++ b/content/publicationsContent.json
@@ -1,36 +1,30 @@
 {
   "fr": {
-    "guides": "Guides",
     "articles": "Articles",
     "press": "Le cabinet dans la presse",
     "episode": "Épisode",
     "readingTime": "min de lecture",
     "series": "Guide",
-    "field": "Domaine",
     "author": "Écrit par",
     "authorRole": "Avocate aux barreaux de Paris et de Californie",
     "source": "Lire l'article d'origine",
     "previous": "Épisode précédent",
     "next": "Épisode suivant",
     "backToIndex": "Toutes les publications",
-    "relatedExpertise": "Voir le champ de compétence",
     "empty": "Aucune publication pour le moment."
   },
   "en": {
-    "guides": "Guides",
     "articles": "Articles",
     "press": "The firm in the press",
     "episode": "Episode",
     "readingTime": "min read",
     "series": "Guide",
-    "field": "Practice area",
     "author": "Written by",
     "authorRole": "Attorney at the Paris and California bars",
     "source": "Read the original article",
     "previous": "Previous episode",
     "next": "Next episode",
     "backToIndex": "All publications",
-    "relatedExpertise": "See the practice area",
     "empty": "No publications yet."
   }
 }

--- a/context/locales-context.jsx
+++ b/context/locales-context.jsx
@@ -1,0 +1,22 @@
+import { createContext } from 'react';
+
+// Which languages the page on screen actually exists in.
+//
+// The head already gets this right: a French-only publication emits one hreflang
+// and no English alternate. The language switcher had no way to know, so it went
+// on offering a link to a page that does not exist. This carries the same answer
+// from the page down to the picker.
+//
+// Null means "no page said", and the picker falls back to its old behaviour of
+// assuming the same path exists in both.
+export const LocalesContextSchema = createContext(null);
+
+function LocalesContext({ value, children }) {
+  return (
+    <LocalesContextSchema.Provider value={value}>
+      {children}
+    </LocalesContextSchema.Provider>
+  );
+}
+
+export default LocalesContext;

--- a/docs/publications-editorial-brief.md
+++ b/docs/publications-editorial-brief.md
@@ -1,0 +1,403 @@
+# Publications: editorial brief
+
+For anyone writing for `/publications`. Read this before writing the first line.
+It is written in English to match the rest of the repository documentation; the
+titles, examples and required phrasings are French because the copy is.
+
+---
+
+## 1. Why this section exists
+
+Search Console, twelve months to August 2026: 897 clicks against 50,788
+impressions. Eighty-seven per cent of the attributable clicks are the firm's own
+name. Queries pairing a field of criminal law with "paris" sat at **average
+position 61** and returned five clicks in a year.
+
+The reason is size. All ten French expertise pages together are about 1,850
+words. The pages that rank on page one for these terms are an order of magnitude
+larger. No technical fix moves position 61 while the site has nothing to read.
+
+One thing on this domain has ranked on page one: the *Guide de survie en garde à
+vue*, five bilingual episodes written by Alice Ouaknine. Episode 1 alone pulled
+**12,791 impressions at position 6.7**, more impressions than the home page at a
+third of the position. The whole guide is 4,602 French words, more than twice the
+entire expertise section.
+
+That guide is the model. This brief is that model written down.
+
+---
+
+## 2. Who is reading
+
+Two profiles, and a piece is written for one of them, never both.
+
+**The organisation.** A general counsel, a compliance officer, a DRH, a finance
+director. Reads on a laptop, at work, scoping a problem before deciding whether
+to instruct anyone. Wants method, sequence and risk. Will read 1,000 words and
+judge the firm's competence from them. This is the reader for **Guide A** and for
+most of the standalone articles.
+
+**The individual under investigation.** A company director who has been summoned,
+searched, or told an investigation has opened. Often reading on a phone, often at
+speed, often frightened. Wants to know what is about to happen to them and what
+they can do in the next hour. This is the reader for **Guide B**.
+
+Neither is a consumer looking for a definition. Neither is a law student. Do not
+write for a general audience.
+
+---
+
+## 3. The format, taken from the guide that worked
+
+### Shape of a piece
+
+```
+Title, in question or object form
+    One short definitional paragraph. No preamble, no "dans cet article nous
+    verrons".
+
+h4  A named point of law
+    The rule.
+    The nuance or the exception.
+    The recent statutory position ("depuis la loi du 22 avril 2024, ...").
+    Bullets only where the elements are genuinely enumerable.
+
+h4  The next point of law
+    ...
+
+h4  En pratique :
+    h4  An imperative instruction
+        Two or three sentences on what to actually do, and why the obvious
+        move is the wrong one.
+    h4  The next instruction
+        ...
+
+h4  Le rôle de l'avocat
+    (mandatory, see section 4)
+```
+
+### Rules
+
+**Length: 500 to 1,000 words.** The existing episodes run 599, 668, 979, 1,177
+and 1,179. Do not write 2,500-word monoliths; the series is the unit of depth,
+not the individual piece.
+
+**Headings are `h4`.** That is what the existing documents use and what the page
+styles. Name a heading after the thing itself ("Droit de garder le silence"),
+not after its function ("Deuxième point").
+
+**Bold carries the operative sentence.** A reader who skims only the bold must
+still come away with the answer. This is deliberate and it is why the guide
+ranks. Do not bold for emphasis or rhythm; bold the sentence that decides
+something.
+
+**"En pratique" is half the piece.** It is the part no directory and no
+competitor writes, because writing it requires having stood in the room. Voice is
+imperative and direct: *"Relisez bien le procès-verbal de notification de vos
+droits avant de le signer"*, *"Solliciter la visite du médecin est utile, même
+pour quelqu'un en bonne santé"*. Say what people get wrong, not just what the
+rule is.
+
+**Address the reader as "vous"** in Guide B and in anything aimed at an
+individual. Use the impersonal or "l'entreprise" in Guide A.
+
+**Cite the text.** Article number, statute, date. *"en application de l'article
+62-2 du Code de procédure pénale"*. Link to Légifrance where it helps. This is
+the difference between a law firm's writing and content marketing.
+
+**Date-stamp the law.** When a rule changed recently, say when. When a piece
+later goes out of date, revise it in place and update `publishedAt`; do not
+publish a correction as a new piece.
+
+---
+
+## 4. Every piece states the role of the lawyer
+
+**This is a house rule, not a suggestion.** Every article and every episode
+carries a passage that makes explicit what an avocat does at that point in the
+process.
+
+### Why
+
+1. **It is the only part the reader cannot get elsewhere.** Légifrance has the
+   text. A directory has the definition. What an avocat actually does at that
+   moment, and what it changes, exists nowhere else.
+2. **It is the credibility signal.** Legal content is what Google classes as
+   YMYL, where the quality bar is harshest. Writing that demonstrably comes from
+   practice rather than from research is what clears it.
+3. **It is how the reader works out that they need help.** Not by being told to
+   call, but by understanding what a lawyer would do that they cannot.
+
+### How
+
+Put it in the "En pratique" section or as its own closing `h4`
+("Le rôle de l'avocat", "Ce que fait l'avocat à ce stade", or named for the
+specific act).
+
+Answer, concretely:
+
+- **What the lawyer does.** The act, the deadline, the document, the argument.
+  Name it.
+- **What it changes.** The procedural consequence. This is the important part.
+- **When to instruct.** The trigger moment, not "le plus tôt possible".
+- **What happens without one.** Factually, without dramatising.
+- **Where it applies**, the cross-border or bilingual dimension: Alice is
+  admitted to the Paris and California bars, which is the firm's genuine
+  differentiator and is under-used across the site.
+
+### The model
+
+From episode 1 of the existing guide, which is exactly right:
+
+> Il est très fortement conseillé de se prévaloir de ce droit et de demander,
+> même si votre avocat n'est pas disponible ou n'entend pas se déplacer, à être
+> assisté d'un avocat commis d'office. **En effet, et sauf dans certains cas
+> exceptionnels, aucune audition ne peut débuter sans la présence de l'avocat dès
+> lors que son intervention a été demandée.**
+
+Note what it does: it gives a concrete procedural consequence, it corrects a
+common mistake, and it never once praises the firm.
+
+### Never
+
+- No self-promotion, no superlatives, no "notre cabinet est reconnu pour".
+- No promised or implied outcomes.
+- No client facts, however anonymised. See section 5.
+- No comparison with other firms or lawyers.
+- Not a call-to-action paragraph. The page already links to the practice area and
+  to contact. A CTA in the body reads as advertising and undoes the credibility
+  the rest of the piece just built.
+
+---
+
+## 5. Déontologie and compliance
+
+**Professional secrecy is absolute.** No case, no client, no fact learned in
+practice, however disguised. Illustrations are hypothetical or drawn from
+published decisions, and published decisions are cited as such.
+
+**Advertising rules bind this content.** An avocat's professional communication
+must be sincere, must respect professional secrecy, and must not contain
+self-praise, comparison with others, or claims about results. Write to inform,
+never to solicit. **Alice validates every piece before publication.** If a
+passage feels like marketing, it is.
+
+**Nothing here is legal advice, and the writing should not read as if it were
+directed at a particular reader's situation.** Describe the rule and the
+practice; do not instruct an individual on their own case.
+
+**Do not generate this content with AI.** Legal content sits in the harshest
+category Google assesses. Machine-written legal text on a practising lawyer's
+site risks a manual action that would cost more than the whole programme is
+worth, and it will be factually wrong in ways a non-lawyer cannot see. A legal
+editor working from Alice's dictation is fine. A model is not.
+
+---
+
+## 6. SEO rules
+
+**One target query per piece**, chosen before writing, stated in the brief for
+that piece. Write for the reader; the query decides the title and the first
+paragraph, nothing else.
+
+**Title.** The searcher's words, not the profession's. "Que remettre au parquet à
+l'issue d'une enquête interne" beats "De la transmission des conclusions
+d'investigation". Keep it under about 60 characters where possible; the page
+appends the firm name automatically.
+
+**First paragraph** answers the title's question directly. Do not build up to it.
+This is what gets lifted into a featured snippet.
+
+**Link internally, always.** Every piece links to at least: its own practice area
+page, and one or two related pieces. Guide episodes link to the neighbouring
+episodes by name. The existing guide already does this in prose and it is a large
+part of why it ranks. Internal links open in the same tab; the site handles that.
+
+**Do not repeat the query.** Once in the title, once in the first paragraph, then
+write normally. Repetition reads badly and does not help.
+
+**No thin pieces.** Under 500 words, it should be a section of another piece, not
+its own page.
+
+---
+
+## 7. Working in Sanity
+
+Documents are of type `post`. Fill:
+
+| Field | Notes |
+|---|---|
+| `contentfr.titlefr` | French title |
+| `contentfr.bodyfr` | French body |
+| `contenten.titleen` / `contenten.bodyen` | Only for pieces marked `*` in the list |
+| `slug` | One slug, shared by both languages. Set it deliberately; if left empty it is derived from the French title |
+| `series` | The guide name, exactly the same string on every episode of that guide |
+| `episode` | Number, for ordering |
+| `relatedExpertise` | Reference to the practice area. Drives the on-page link and the structured data |
+| `author` | `Alice Ouaknine` |
+| `publishedAt` | Publication date. Update it when the piece is revised |
+| `filter` | `fact` for the firm's own writing, `press` for a press mention |
+| `source` | Press mentions only: the URL of the original article |
+
+`language` stays `all` for anything with both a French and an English body,
+otherwise `fr`.
+
+**Series names must match exactly.** The existing guide is stored under three
+different spellings ("Guide de survie en garde à vue", "Guide de survie à la
+garde à vue en France", and a variant of "Episode" without the accent), which is
+why the `series` field now exists. One string, copied, every time.
+
+---
+
+## 8. The list
+
+45 pieces. Two guides that read as complete units, plus standalone articles the
+guides link into. `*` means write it in both French and English.
+
+### Guide A: *Conduire une enquête interne*
+
+Audience: the organisation. Episodes 1 to 7 expand the paragraph already on
+`/expertise/enquetes-internes`, which is the outline.
+
+| | |
+|---|---|
+| A1 | Ouvrir une enquête interne : déclencheurs, périmètre, calendrier |
+| A2 | Qui doit mener l'enquête : interne, avocat, tiers |
+| A3 | Les mesures conservatoires : mise à pied, suspension d'accès, préservation des preuves |
+| A4 | L'audition : cadre loyal, information préalable, assistance |
+| A5 | Collecter les preuves sans les fragiliser : messagerie, postes de travail, RGPD |
+| A6 | Le rapport : faits établis, faits non établis, éléments invérifiables |
+| A7 | Les suites : disciplinaires, pénales, organisationnelles |
+| A8 | Le signalement d'un lanceur d'alerte : ce que la loi impose |
+| A9 | Harcèlement moral ou sexuel : les particularités de l'enquête |
+| A10 | Que remettre au parquet, et quand |
+| A11 | Secret professionnel et confidentialité du rapport |
+| A12* | L'enquête transfrontalière : standards américains et droit français |
+
+### Guide B: *Guide de survie du dirigeant mis en cause*
+
+Audience: the individual. Same register as the garde à vue guide: someone in
+trouble who needs to know what happens next.
+
+| | |
+|---|---|
+| B1 | La convocation : audition libre, garde à vue, témoin assisté, mise en examen |
+| B2 | La perquisition dans l'entreprise : les premières heures |
+| B3 | Vos droits en audition libre |
+| B4 | Le droit de garder le silence quand on dirige une entreprise |
+| B5 | Saisies et confiscations : protéger la trésorerie et les actifs |
+| B6 | Personne physique, personne morale : qui est poursuivi, et pour quoi |
+| B7 | La délégation de pouvoirs : ce qui vous protège, ce qui ne vous protège pas |
+| B8 | Comprendre la qualification : le panorama des infractions d'affaires |
+| B9 | L'instruction : mise en examen, contrôle judiciaire, expertises |
+| B10 | AMF ou PNF : qui vous poursuit, et selon quelle procédure |
+| B11 | La CJIP : ce que l'entreprise négocie, ce que le dirigeant ne peut pas |
+| B12 | Jusqu'à quand peut-on être poursuivi : la prescription |
+| B13 | Le procès correctionnel : déroulement et peines encourues |
+
+### Articles
+
+Named legal objects, explained in depth. The guides link into these.
+
+| | |
+|---|---|
+| S1 | Sapin II, article 17 : les huit piliers du dispositif anticorruption |
+| S2 | Le contrôle de l'AFA : ce qui est vérifié, comment s'y préparer |
+| S3 | La cartographie des risques de corruption |
+| S4 | Le Parquet National Financier : compétence, saisine, organisation |
+| S5 | La procédure de sanction devant l'AMF |
+| S6 | L'abus de biens sociaux : éléments constitutifs, prescription, sanctions |
+| S7 | L'abus de confiance en entreprise |
+| S8 | Corruption et trafic d'influence : les textes et leur portée |
+| S9 | La prise illégale d'intérêts |
+| S10 | Le blanchiment : l'infraction autonome |
+| S11 | Escroquerie, faux et usage de faux en entreprise |
+| S12 | Le délit d'initié et le manquement d'initié |
+| S13 | La fraude au président et le faux ordre de virement |
+| S14 | Le détournement d'actifs : typologies et détection |
+| S15 | Discrimination et agissements sexistes : conduire l'enquête |
+| S16 | Fuite de données et usage abusif des outils de l'entreprise |
+| S17 | La responsabilité pénale de la personne morale (article 121-2) |
+| S18* | La loi de blocage face au discovery américain |
+| S19* | Entreprise française visée par le DOJ : premiers réflexes |
+| S20* | FCPA et droit français : le risque de double poursuite |
+
+### On the English versions
+
+Only four pieces are written in both languages, and they are the four where
+English search intent is real and commercially useful. The garde à vue guide was
+translated in full and the English half brought 12,791 impressions of dictionary
+traffic from outside France that converted to nothing. Do not translate for the
+sake of it.
+
+---
+
+## 9. Timetable
+
+Three pieces a month. **Each guide ships complete before the next begins**: a
+guide whose episodes trickle out over ten months never reads as finished, and its
+internal linking stays weak until it is.
+
+| Month | Pieces | |
+|---|---|---|
+| Sept 2026 | *(no writing)* | Section ships. Sanity fields added, index renamed, sitemap resubmitted |
+| Oct 2026 | A1, A2, A3 | |
+| Nov 2026 | A4, A5, A6 | |
+| Dec 2026 | A7, A8, A9 | |
+| Jan 2027 | A10, A11, A12* | **Guide A complete** |
+| Feb 2027 | B1, B2, B3 | |
+| Mar 2027 | B4, B5, B6 | |
+| Apr 2027 | B7, B8, B9 | |
+| May 2027 | B10, B11, B12 | |
+| Jun 2027 | B13, S1, S2 | **Guide B complete** |
+| Jul 2027 | S3, S4, S5 | |
+| Aug 2027 | S6, S7, S8 | |
+| Sept 2027 | S9, S10, S11 | |
+| Oct 2027 | S12, S13, S14 | |
+| Nov 2027 | S15, S16, S17 | |
+| Dec 2027 | S18*, S19*, S20* | **Complete: 45 pieces** |
+
+About 36,000 words over fifteen months, roughly 2,400 a month. At two pieces a
+month instead the same programme runs to mid-2028; the ordering does not change,
+the guides simply complete in month 6 and month 13.
+
+### What to expect
+
+Nothing for the first three months. Guide A should begin showing positions around
+month five or six. The compounding only becomes visible once a guide is complete
+and cross-linked.
+
+These are low-volume terms. At maturity the realistic figure is a few hundred
+clicks a month, not thousands. Every one of them is a general counsel or a
+director with a problem, which for this practice is the right trade. The second
+return is harder to measure and probably larger: a firm that has published twelve
+serious pieces on internal investigations wins the beauty parade against one that
+has not, regardless of search.
+
+---
+
+## 10. Before a piece is published
+
+- [ ] One target query, and the title uses the searcher's words
+- [ ] First paragraph answers the title directly
+- [ ] 500 to 1,000 words
+- [ ] `h4` headings, named after the thing itself
+- [ ] Bold carries the operative sentences; skimming the bold gives the answer
+- [ ] An "En pratique" section in imperative voice
+- [ ] **A passage on the role of the lawyer, concrete and non-promotional**
+- [ ] Statute and article numbers cited; recent changes dated
+- [ ] Links to its practice area page and to at least one related piece
+- [ ] Guide episodes link to their neighbours by name
+- [ ] No client facts, no outcome claims, no self-praise, no comparison
+- [ ] Sanity fields filled, `series` string copied exactly
+- [ ] Read and approved by Alice
+
+---
+
+## Related
+
+- `CLAUDE.md` at the repository root: the design system these pages render in
+- `/expertise/enquetes-internes` and `/expertise/droit-penal-des-affaires`: the
+  two practice areas this programme supports
+- The five existing episodes of the *Guide de survie en garde à vue*, which are
+  the worked example of everything above

--- a/docs/publications-editorial-brief.md
+++ b/docs/publications-editorial-brief.md
@@ -18,12 +18,31 @@ words. The pages that rank on page one for these terms are an order of magnitude
 larger. No technical fix moves position 61 while the site has nothing to read.
 
 One thing on this domain has ranked on page one: the *Guide de survie en garde à
-vue*, five bilingual episodes written by Alice Ouaknine. Episode 1 alone pulled
-**12,791 impressions at position 6.7**, more impressions than the home page at a
-third of the position. The whole guide is 4,602 French words, more than twice the
-entire expertise section.
+vue*, five bilingual episodes written by Alice Ouaknine. The whole guide is 4,602
+French words, more than twice the entire expertise section.
 
-That guide is the model. This brief is that model written down.
+Read the numbers carefully, because they carry two different lessons.
+
+| | Clicks | Impressions | Position |
+|---|---|---|---|
+| French guide, all five episodes | 3 | 112 | 6.3 to 7.5 |
+| English episode 1 alone | 59 | 12,791 | 6.7 |
+
+**The format ranks.** Every episode sits on page one in both languages. That is
+the part to copy: the structure in section 3, and above all the "En pratique"
+half that no directory writes.
+
+**The French titles match nothing anyone types.** Not one query in twelve months
+of Search Console contains the word "guide". The French episodes rank at position
+6 on searches that barely exist, because they are titled for the series
+("Connaître ses droits") rather than for the question a reader asks
+("Combien de temps peut durer une garde à vue ?"). The English episode won its
+12,791 impressions by accident of matching a real query, `garde a vue in english`,
+and that traffic converted to almost nothing, which is why section 8 tells you not
+to translate for its own sake.
+
+So: keep the format, and title every piece for the search, not for the series.
+Section 6 is not optional polish; it is the half of this the guide got wrong.
 
 ---
 
@@ -231,21 +250,25 @@ Documents are of type `post`. Fill:
 | `contentfr.bodyfr` | French body |
 | `contenten.titleen` / `contenten.bodyen` | Only for pieces marked `*` in the list |
 | `slug` | One slug, shared by both languages. Set it deliberately; if left empty it is derived from the French title |
-| `series` | The guide name, exactly the same string on every episode of that guide |
-| `episode` | Number, for ordering |
+| `series` | **Pending the studio schema change (see the timetable).** The guide name, exactly the same string on every episode of that guide |
+| `episode` | **Pending the studio schema change.** Number, for ordering |
 | `relatedExpertise` | Reference to the practice area. Drives the on-page link and the structured data |
-| `author` | `Alice Ouaknine` |
+| `author` | `Alice Ouaknine` on the firm's own writing. On a press mention, the outlet or the journalist: the index prints this beside the date as the byline |
 | `publishedAt` | Publication date. Update it when the piece is revised |
 | `filter` | `fact` for the firm's own writing, `press` for a press mention |
-| `source` | Press mentions only: the URL of the original article |
+| `source` | Press mentions only: the URL of the original article. Filling it marks the document as a press mention whatever `filter` says, so a reference link for the firm's own writing belongs in the body, not here |
 
-`language` stays `all` for anything with both a French and an English body,
-otherwise `fr`.
+**What decides whether a piece appears in a language is whether that language's
+body is filled**, nothing else. `language` is a legacy field the publications
+section does not read; leave it as you find it.
 
-**Series names must match exactly.** The existing guide is stored under three
-different spellings ("Guide de survie en garde à vue", "Guide de survie à la
-garde à vue en France", and a variant of "Episode" without the accent), which is
-why the `series` field now exists. One string, copied, every time.
+**Until `series` and `episode` exist, the title carries them.** Write an episode
+title as `<Guide> - Épisode <n> : <subtitle>`; that is the shape the code parses
+to group a guide and to set the page heading. Use one spelling of the guide name
+every time: the existing guide is stored under three ("Guide de survie en garde à
+vue", "Guide de survie à la garde à vue en France", and a variant of "Episode"
+without the accent), which is what the fields will fix. When they land, the same
+exact-string rule applies to the field.
 
 ---
 

--- a/docs/publications-editorial-brief.md
+++ b/docs/publications-editorial-brief.md
@@ -101,9 +101,10 @@ h4  Le rôle de l'avocat
 and 1,179. Do not write 2,500-word monoliths; the series is the unit of depth,
 not the individual piece.
 
-**Headings are `h4`.** That is what the existing documents use and what the page
-styles. Name a heading after the thing itself ("Droit de garder le silence"),
-not after its function ("Deuxième point").
+**Headings are `h4`.** A studio convention, for consistency between documents:
+the page renders every heading level as an `h2` and styles them alike, so the
+level you pick does not change what a reader sees. Name a heading after the thing
+itself ("Droit de garder le silence"), not after its function ("Deuxième point").
 
 **Bold carries the operative sentence.** A reader who skims only the bold must
 still come away with the answer. This is deliberate and it is why the guide
@@ -252,23 +253,24 @@ Documents are of type `post`. Fill:
 | `slug` | One slug, shared by both languages. Set it deliberately; if left empty it is derived from the French title |
 | `series` | **Pending the studio schema change (see the timetable).** The guide name, exactly the same string on every episode of that guide |
 | `episode` | **Pending the studio schema change.** Number, for ordering |
-| `relatedExpertise` | Reference to the practice area. Drives the on-page link and the structured data |
+| `relatedExpertise` | Reference to the practice area. Drives the on-page link and the structured data, but only while the referenced document's title still matches an entry in `libs/expertisePairs.js`. Rename a field of expertise in the studio and both the link and the `about` node silently disappear until a developer updates that file |
 | `author` | `Alice Ouaknine` on the firm's own writing. On a press mention, the outlet or the journalist: the index prints this beside the date as the byline |
-| `publishedAt` | Publication date. Update it when the piece is revised |
+| `publishedAt` | Publication date. **Required**: an undated document is invisible everywhere, and a future date holds the piece back until then, which is how the timetable below is loaded in advance. Update it when the piece is revised |
 | `filter` | `fact` for the firm's own writing, `press` for a press mention |
 | `source` | Press mentions only: the URL of the original article. Filling it marks the document as a press mention whatever `filter` says, so a reference link for the firm's own writing belongs in the body, not here |
 
-**What decides whether a piece appears in a language is whether that language's
-body is filled**, nothing else. `language` is a legacy field the publications
-section does not read; leave it as you find it.
+**A piece appears in a language when that language's body is filled and
+`publishedAt` has passed.** Nothing else gates it: `language` is a legacy field
+the publications section does not read, so leave it as you find it.
 
 **Until `series` and `episode` exist, the title carries them.** Write an episode
 title as `<Guide> - Épisode <n> : <subtitle>`; that is the shape the code parses
 to group a guide and to set the page heading. Use one spelling of the guide name
-every time: the existing guide is stored under three ("Guide de survie en garde à
-vue", "Guide de survie à la garde à vue en France", and a variant of "Episode"
-without the accent), which is what the fields will fix. When they land, the same
-exact-string rule applies to the field.
+every time. The existing guide is stored under two ("Guide de survie en garde à
+vue" and "Guide de survie à la garde à vue en France"), and two spellings split
+one guide into two sections on `/publications`, each with its own episode rail.
+The accented and unaccented "Épisode" are both parsed, so only the guide name
+matters. When the `series` field lands, the same exact-string rule applies to it.
 
 ---
 
@@ -349,7 +351,7 @@ Named legal objects, explained in depth. The guides link into these.
 
 Only four pieces are written in both languages, and they are the four where
 English search intent is real and commercially useful. The garde à vue guide was
-translated in full and the English half brought 12,791 impressions of dictionary
+translated in full and its English episode 1 alone brought 12,791 impressions of dictionary
 traffic from outside France that converted to nothing. Do not translate for the
 sake of it.
 

--- a/libs/expertise.js
+++ b/libs/expertise.js
@@ -1,15 +1,9 @@
 import clientApi from './clientApi';
+import { slugify } from './slug';
 
 // The CMS has no slug field on an expertise item, so the URL is derived from
-// the title — stable for as long as the title is.
-export const expertiseSlug = title =>
-  (title ?? '')
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
+// the title, stable for as long as the title is.
+export const expertiseSlug = slugify;
 
 const EXPERTISE_QUERY = `*[_type == "expertise" && language == $locale][0]{
   titleseo,

--- a/libs/href.js
+++ b/libs/href.js
@@ -1,0 +1,42 @@
+// Where a CMS-authored link actually goes.
+//
+// Link marks and the `source` field are free text an editor fills, so they are
+// untrusted input at a rendering boundary. This module is the single place that
+// decides, because the same decision written twice drifted: the allowlist landed
+// in the rich-text renderer and not on the sibling anchor one file over.
+
+const SITE_HOST = new URL(
+  process.env.NEXT_PUBLIC_HOST ?? 'https://www.ouaknine-avocats.com'
+).hostname;
+
+// A same-origin path, or null when the link leaves the site.
+//
+// Resolved rather than pattern-matched, for two reasons. The CMS authors
+// internal links as absolute URLs, so a startsWith('/') test sends the guide's
+// own cross-links out to a new tab; and the URL parser strips tabs and treats a
+// backslash as a slash, so "/\evil.com" reads as a path and navigates off-site.
+export const internalPath = href => {
+  const clean = (href ?? '').replace(/[\t\n\r]/g, '');
+  if (clean.startsWith('#')) return clean;
+
+  try {
+    const url = new URL(clean, 'https://internal.invalid');
+
+    // Compared against the parsed hostname, so userinfo ("https://site@evil.com")
+    // and a lookalike suffix ("notouaknine-avocats.com") both fail.
+    const internal =
+      url.hostname === 'internal.invalid' ||
+      url.hostname === SITE_HOST ||
+      url.hostname.endsWith(`.${SITE_HOST}`);
+
+    return internal ? `${url.pathname}${url.search}${url.hash}` : null;
+  } catch (err) {
+    return null;
+  }
+};
+
+// Whether a link that leaves the site is one we are willing to render at all.
+// An allowlist: anything unrecognised keeps its text and loses its href, so a
+// `javascript:` or `data:` URL can never reach an anchor.
+export const isSafeExternal = href =>
+  /^(https?|mailto|tel):/i.test((href ?? '').trim());

--- a/libs/href.js
+++ b/libs/href.js
@@ -1,3 +1,5 @@
+import { SITE_HOSTS } from './site.js';
+
 // Where a CMS-authored link actually goes.
 //
 // Link marks and the `source` field are free text an editor fills, so they are
@@ -5,28 +7,6 @@
 // decides, because the same decision written twice drifted: the allowlist landed
 // in the rich-text renderer and not on the sibling anchor one file over.
 
-const FALLBACK_HOST = 'https://www.ouaknine-avocats.com';
-
-// The registrable host, without the www label, so the apex and every subdomain
-// both count as the site. Deriving it from the www URL and testing
-// `endsWith('.' + host)` matched only `*.www...`, which is nothing, and pushed
-// the bare domain an editor gets by copying it onto the external branch.
-//
-// `||` not `??`: a variable created on Vercel and left blank is an empty string,
-// not undefined. And the parse is guarded, because this runs at module scope in
-// a module every content page imports: a host without a scheme would otherwise
-// throw at import and take the whole site down, where the other readers of the
-// same variable only produce a bad canonical.
-const SITE_HOST = (() => {
-  try {
-    return new URL(process.env.NEXT_PUBLIC_HOST || FALLBACK_HOST).hostname.replace(
-      /^www\./,
-      ''
-    );
-  } catch (err) {
-    return new URL(FALLBACK_HOST).hostname.replace(/^www\./, '');
-  }
-})();
 
 // A same-origin path, or null when the link leaves the site.
 //
@@ -41,12 +21,12 @@ export const internalPath = href => {
   try {
     const url = new URL(clean, 'https://internal.invalid');
 
-    // Compared against the parsed hostname, so userinfo ("https://site@evil.com")
-    // and a lookalike suffix ("notouaknine-avocats.com") both fail.
+    // Exact hosts, not a suffix. Compared against the parsed hostname, so
+    // userinfo ("https://site@evil.com") and a lookalike ("notouaknine-…") both
+    // fail; and a real subdomain like blog.ouaknine-avocats.com is somewhere
+    // else, so calling it internal would drop its host and land on the apex.
     const internal =
-      url.hostname === 'internal.invalid' ||
-      url.hostname === SITE_HOST ||
-      url.hostname.endsWith(`.${SITE_HOST}`);
+      url.hostname === 'internal.invalid' || SITE_HOSTS.includes(url.hostname);
 
     if (!internal) return null;
 

--- a/libs/href.js
+++ b/libs/href.js
@@ -5,9 +5,28 @@
 // decides, because the same decision written twice drifted: the allowlist landed
 // in the rich-text renderer and not on the sibling anchor one file over.
 
-const SITE_HOST = new URL(
-  process.env.NEXT_PUBLIC_HOST ?? 'https://www.ouaknine-avocats.com'
-).hostname;
+const FALLBACK_HOST = 'https://www.ouaknine-avocats.com';
+
+// The registrable host, without the www label, so the apex and every subdomain
+// both count as the site. Deriving it from the www URL and testing
+// `endsWith('.' + host)` matched only `*.www...`, which is nothing, and pushed
+// the bare domain an editor gets by copying it onto the external branch.
+//
+// `||` not `??`: a variable created on Vercel and left blank is an empty string,
+// not undefined. And the parse is guarded, because this runs at module scope in
+// a module every content page imports: a host without a scheme would otherwise
+// throw at import and take the whole site down, where the other readers of the
+// same variable only produce a bad canonical.
+const SITE_HOST = (() => {
+  try {
+    return new URL(process.env.NEXT_PUBLIC_HOST || FALLBACK_HOST).hostname.replace(
+      /^www\./,
+      ''
+    );
+  } catch (err) {
+    return new URL(FALLBACK_HOST).hostname.replace(/^www\./, '');
+  }
+})();
 
 // A same-origin path, or null when the link leaves the site.
 //
@@ -29,7 +48,12 @@ export const internalPath = href => {
       url.hostname === SITE_HOST ||
       url.hostname.endsWith(`.${SITE_HOST}`);
 
-    return internal ? `${url.pathname}${url.search}${url.hash}` : null;
+    if (!internal) return null;
+
+    // `new URL` resolves `..` before pathname is read, so "/..//evil.com" arrives
+    // here as the protocol-relative "//evil.com". Collapsing the leading slashes
+    // keeps this function's promise: what it returns is a path on this site.
+    return `${url.pathname.replace(/^\/+/, '/')}${url.search}${url.hash}`;
   } catch (err) {
     return null;
   }

--- a/libs/localePath.js
+++ b/libs/localePath.js
@@ -17,8 +17,16 @@ const counterpartSlug = (router, target) =>
 // A pair that falls out of date — a field renamed in the studio, which changes
 // its slug — sends the switch to the index rather than to a URL that does not
 // exist.
-const localePath = (router, target) => {
+const localePath = (router, target, availableLocales) => {
   const { pathname, query } = router;
+
+  // A page that only exists in some languages says so through the locales
+  // context. Switching to one it does not have goes to that section's index
+  // rather than to a URL that 404s: every press cutting is French only, and the
+  // editorial brief plans most new pieces the same way.
+  if (availableLocales && !availableLocales.includes(target)) {
+    return pathname.replace(/\/\[[^\]]+\]$/, '') || '/';
+  }
 
   if (pathname !== FIELD_ROUTE) return { pathname, query };
 

--- a/libs/localePath.js
+++ b/libs/localePath.js
@@ -1,4 +1,5 @@
 import EXPERTISE_PAIRS from './expertisePairs';
+import { slugify } from './slug';
 
 const SIDE = { fr: 0, en: 1 };
 
@@ -30,6 +31,18 @@ const localePath = (router, target) => {
 // `/` in French and `/en` in English.
 export const withLocale = (locale, path) =>
   locale === 'fr' ? path : `/${locale}${path === '/' ? '' : path}`;
+
+// A publication references one field of expertise, and the two languages are
+// separate Sanity documents with unrelated slugs. Resolve that reference to the
+// field's slug in the language being read; null when the pair has no counterpart,
+// so the caller can drop the link rather than publish one that 404s.
+export const expertiseSlugIn = (title, locale) => {
+  const slug = slugify(title);
+  if (!slug) return null;
+
+  const pair = EXPERTISE_PAIRS.find(slugs => slugs.includes(slug));
+  return pair?.[SIDE[locale]] ?? null;
+};
 
 // Both public paths for a field of expertise, from either side's slug. The
 // landing page renders the first field and needs to present itself as that

--- a/libs/publication-fields.js
+++ b/libs/publication-fields.js
@@ -1,0 +1,112 @@
+import { slugify } from './slug.js';
+
+// The pure half of the publications module: everything that derives a value
+// from a document without asking the CMS for anything. It lives apart from the
+// fetchers so it can be loaded, and checked, without building a Sanity client.
+//
+// Imports carry their extension deliberately. Node's ESM resolver rejects the
+// extensionless form webpack accepts, and an unloadable module cannot be tested.
+
+export const otherLocale = locale => (locale === 'fr' ? 'en' : 'fr');
+
+// Whether the practice wrote this or was written about. `filter` is the field
+// the studio sets, and it is the answer when it is set; but it can be left
+// empty, and a document carrying the URL of someone else's article is not the
+// practice's own writing whatever the field says.
+//
+// Worth being sure about: this decides the section on the index, whether the
+// author block appears, and whether the structured data names Alice Ouaknine as
+// the author. Defaulting the other way publishes her as the author of Le Monde's
+// copy.
+export const isPress = post => post?.filter === 'press' || Boolean(post?.source);
+
+// One slug for both languages, from the explicit field when the studio carries
+// one and from the French title otherwise. Deriving it from each locale's own
+// title would give the two versions different URLs, which is a 404 behind every
+// hreflang; sharing it makes a publication the same path in either language and
+// spares it the counterpart lookup a field of expertise needs.
+//
+// Derived in JS rather than stored, which is why a lookup by slug has to match
+// against a fetched list instead of filtering in GROQ.
+const publicationSlug = post =>
+  slugify(post?.slug) || slugify(post?.title) || post?._id;
+
+export const withSlug = post => ({ ...post, slug: publicationSlug(post) });
+
+// Formatting in the runtime's own zone renders one day on the server and another
+// in the browser for any evening timestamp: a hydration mismatch and a date off
+// by one. The practice is in Paris, so that is the zone the date means.
+export const formatDate = (iso, locale, options) =>
+  new Date(iso).toLocaleDateString(locale === 'en' ? 'en-GB' : 'fr-FR', {
+    timeZone: 'Europe/Paris',
+    ...options,
+  });
+
+// Until the studio carries series and episode as fields, an episode title holds
+// them in prose: "Guide de survie en garde à vue - Épisode 2 : Connaître …".
+//
+// The pattern is deliberately narrow. A standalone article whose title merely
+// contains a dash must come back whole rather than cut in half.
+const EPISODE =
+  /^(.+?)\s*[–—-]\s*(?:Épisodes?|Episodes?|Ep\.?)\s*(\d+)\s*[:.]?\s*(.*)$/i;
+
+// The fields win when the studio carries them, but the title is still stripped:
+// a document keeps its full "<Guide> - Épisode 1 : <subtitle>" title, so trusting
+// the field alone would put the series name back into the heading the moment an
+// editor filled the field the editorial brief asks them to fill.
+export const splitTitle = post => {
+  const raw = post?.title ?? '';
+  const match = EPISODE.exec(raw);
+
+  // An episode with no subtitle after the number would otherwise leave an empty
+  // heading and a title tag reading " | Cabinet Ouaknine".
+  const title = match ? match[3].trim() || raw : raw;
+  const episode = match ? Number(match[2]) : null;
+
+  if (post?.series) {
+    return { series: post.series, episode: post.episode ?? episode, title };
+  }
+
+  return { series: match ? match[1].trim() : null, episode, title };
+};
+
+// The episodes of one guide, in reading order, so an episode can render its own
+// series navigation and the index can group by guide.
+//
+// The date is the tie-break, not decoration: an editor who fills `series` and
+// leaves `episode` empty gives every episode a null number, and without it the
+// guide would list in reverse.
+export const seriesOf = (posts, series) =>
+  posts
+    .map(post => ({ post, ...splitTitle(post) }))
+    .filter(entry => entry.series && entry.series === series)
+    .sort(
+      (a, b) =>
+        (a.episode ?? 0) - (b.episode ?? 0) ||
+        new Date(a.post.publishedAt ?? 0) - new Date(b.post.publishedAt ?? 0)
+    );
+
+// Three surfaces on the index: the guides, grouped; the standalone articles;
+// and what the press has written.
+export const groupPublications = posts => {
+  const written = posts.filter(post => !isPress(post));
+
+  const guides = [];
+  const articles = [];
+
+  written.forEach(post => {
+    const { series } = splitTitle(post);
+    if (!series) return articles.push(post);
+
+    const guide = guides.find(entry => entry.series === series);
+    if (guide) return guide.episodes.push(post);
+
+    guides.push({ series, episodes: [post] });
+  });
+
+  guides.forEach(guide => {
+    guide.episodes = seriesOf(guide.episodes, guide.series).map(e => e.post);
+  });
+
+  return { guides, articles, press: posts.filter(isPress) };
+};

--- a/libs/publications.js
+++ b/libs/publications.js
@@ -8,13 +8,22 @@ export const otherLocale = locale => (locale === 'fr' ? 'en' : 'fr');
 // Portable text lives at content<locale>.body<locale>, which GROQ cannot reach
 // through a parameter, so the locale is interpolated. It is checked against the
 // two the site has rather than trusted from the route.
-const projection = locale => {
-  const l = LOCALES.includes(locale) ? locale : 'fr';
+const safeLocale = locale => (LOCALES.includes(locale) ? locale : 'fr');
+
+// Everything but the body. This is what a list needs, and a list is most of what
+// the section does: the index renders ten rows, the series rail renders links,
+// the sitemap renders slugs. Projecting the body into any of them serialises the
+// full text of every publication into the page's __NEXT_DATA__, which measured
+// 227 kB on the index for content it never renders.
+//
+// `hasBody` stands in for the body in the one place a list still needs it: a
+// piece is listed in a language only when it was written in that language.
+const metaProjection = locale => {
+  const l = safeLocale(locale);
   const o = otherLocale(l);
 
   return `{
     _id,
-    language,
     filter,
     author,
     source,
@@ -24,6 +33,28 @@ const projection = locale => {
     "episode": episode,
     "field": relatedExpertise->title,
     "title": coalesce(content${l}.title${l}, content${o}.title${o}),
+    "hasBody": defined(content${l}.body${l}),
+    "readingTime": round(length(pt::text(content${l}.body${l})) / 5 / 180)
+  }`;
+};
+
+// The one caller that actually renders prose asks for it explicitly.
+const bodyProjection = locale => {
+  const l = safeLocale(locale);
+  const o = otherLocale(l);
+
+  return `{
+    _id,
+    filter,
+    author,
+    source,
+    publishedAt,
+    "slug": coalesce(slug.current, contentfr.titlefr, contenten.titleen),
+    "series": series,
+    "episode": episode,
+    "field": relatedExpertise->title,
+    "title": coalesce(content${l}.title${l}, content${o}.title${o}),
+    "hasBody": defined(content${l}.body${l}),
     "body": content${l}.body${l},
     "readingTime": round(length(pt::text(content${l}.body${l})) / 5 / 180)
   }`;
@@ -44,9 +75,9 @@ export const isPress = post => post?.filter === 'press' || Boolean(post?.source)
 
 // Only what the reader can actually read. A French press cutting has no English
 // body, and listing it on the English site would be a link to an empty page.
-const readable = post => Boolean(post?.body?.length);
+const readable = post => Boolean(post?.hasBody);
 
-export const fetchPublications = async locale => {
+const fetchWith = async (projection, locale) => {
   const posts = await clientApi.fetch(
     `*[${PUBLISHED}] | order(publishedAt desc) ${projection(locale)}`
   );
@@ -54,10 +85,43 @@ export const fetchPublications = async locale => {
   return (posts ?? []).filter(readable).map(withSlug);
 };
 
+// Every publication in a language, without the prose. For lists, rails, sitemaps
+// and membership checks.
+export const fetchPublications = locale => fetchWith(metaProjection, locale);
+
+// One publication, prose included. Fetched by slug rather than filtered out of
+// the whole corpus, so an unknown slug costs one query and not a full download.
 export const fetchPublication = async (locale, slug) => {
-  const posts = await fetchPublications(locale);
+  const posts = await fetchWith(bodyProjection, locale);
   return posts.find(post => post.slug === slug) ?? null;
 };
+
+// The publication a legacy /articles/<id> URL was addressing. Looked up by id
+// directly: that path space is unbounded and attacker-chosen, so it must not
+// pull the corpus once per unknown id.
+export const fetchPublicationById = async id => {
+  const post = await clientApi.fetch(
+    `*[_type == "post" && _id == $id][0]{
+      "slug": coalesce(slug.current, contentfr.titlefr, contenten.titleen),
+      publishedAt
+    }`,
+    { id }
+  );
+
+  if (!post?.slug) return null;
+  if (post.publishedAt && new Date(post.publishedAt) > new Date()) return null;
+
+  return { slug: slugify(post.slug) };
+};
+
+// Formatting in the runtime's own zone renders one day on the server and another
+// in the browser for any evening timestamp: a hydration mismatch and a date off
+// by one. The practice is in Paris, so that is the zone the date means.
+export const formatDate = (iso, locale, options) =>
+  new Date(iso).toLocaleDateString(locale === 'en' ? 'en-GB' : 'fr-FR', {
+    timeZone: 'Europe/Paris',
+    ...options,
+  });
 
 // One slug for both languages, from the explicit field when the studio carries
 // one and from the French title otherwise. Deriving it from each locale's own
@@ -77,21 +141,29 @@ const withSlug = post => ({ ...post, slug: publicationSlug(post) });
 const EPISODE = /^(.+?)\s*[–—-]\s*(?:Épisodes?|Episodes?|Ep\.?)\s*(\d+)\s*[:.]?\s*(.*)$/i;
 
 export const splitTitle = post => {
+  const raw = post?.title ?? '';
+  const match = EPISODE.exec(raw);
+
+  // The fields win when the studio carries them, but the title still has to be
+  // stripped: a document keeps its full "<Guide> - Épisode 1 : <subtitle>"
+  // title, so trusting the field alone would put the series name back into the
+  // heading the moment an editor filled the field the brief asks them to fill.
   if (post?.series) {
     return {
       series: post.series,
-      episode: post.episode ?? null,
-      title: post.title ?? '',
+      episode: post.episode ?? (match ? Number(match[2]) : null),
+      title: (match ? match[3].trim() : raw) || raw,
     };
   }
 
-  const match = EPISODE.exec(post?.title ?? '');
-  if (!match) return { series: null, episode: null, title: post?.title ?? '' };
+  if (!match) return { series: null, episode: null, title: raw };
 
+  // An episode with no subtitle after the number would otherwise leave an empty
+  // heading and a title tag reading " | Cabinet Ouaknine".
   return {
     series: match[1].trim(),
     episode: Number(match[2]),
-    title: match[3].trim(),
+    title: match[3].trim() || raw,
   };
 };
 

--- a/libs/publications.js
+++ b/libs/publications.js
@@ -1,0 +1,118 @@
+import clientApi from './clientApi';
+import { slugify } from './slug';
+
+const LOCALES = ['fr', 'en'];
+
+export const otherLocale = locale => (locale === 'fr' ? 'en' : 'fr');
+
+// Portable text lives at content<locale>.body<locale>, which GROQ cannot reach
+// through a parameter, so the locale is interpolated. It is checked against the
+// two the site has rather than trusted from the route.
+const projection = locale => {
+  const l = LOCALES.includes(locale) ? locale : 'fr';
+  const o = otherLocale(l);
+
+  return `{
+    _id,
+    language,
+    filter,
+    author,
+    source,
+    publishedAt,
+    "slug": coalesce(slug.current, contentfr.titlefr, contenten.titleen),
+    "series": series,
+    "episode": episode,
+    "field": relatedExpertise->title,
+    "title": coalesce(content${l}.title${l}, content${o}.title${o}),
+    "body": content${l}.body${l},
+    "readingTime": round(length(pt::text(content${l}.body${l})) / 5 / 180)
+  }`;
+};
+
+const PUBLISHED = '_type == "post" && dateTime(publishedAt) < dateTime(now())';
+
+// Only what the reader can actually read. A French press cutting has no English
+// body, and listing it on the English site would be a link to an empty page.
+const readable = post => Boolean(post?.body?.length);
+
+export const fetchPublications = async locale => {
+  const posts = await clientApi.fetch(
+    `*[${PUBLISHED}] | order(publishedAt desc) ${projection(locale)}`
+  );
+
+  return (posts ?? []).filter(readable).map(withSlug);
+};
+
+export const fetchPublication = async (locale, slug) => {
+  const posts = await fetchPublications(locale);
+  return posts.find(post => post.slug === slug) ?? null;
+};
+
+// One slug for both languages, from the explicit field when the studio carries
+// one and from the French title otherwise. Deriving it from each locale's own
+// title would give the two versions different URLs, which is a 404 behind every
+// hreflang; sharing it makes a publication the same path in either language and
+// spares it the counterpart lookup a field of expertise needs.
+export const publicationSlug = post =>
+  slugify(post?.slug) || slugify(post?.title) || post?._id;
+
+const withSlug = post => ({ ...post, slug: publicationSlug(post) });
+
+// Until the studio carries series and episode as fields, an episode title holds
+// them in prose: "Guide de survie en garde à vue - Épisode 2 : Connaître …".
+//
+// The pattern is deliberately narrow. A standalone article whose title merely
+// contains a dash must come back whole rather than cut in half.
+const EPISODE = /^(.+?)\s*[–—-]\s*(?:Épisodes?|Episodes?|Ep\.?)\s*(\d+)\s*[:.]?\s*(.*)$/i;
+
+export const splitTitle = post => {
+  if (post?.series) {
+    return {
+      series: post.series,
+      episode: post.episode ?? null,
+      title: post.title ?? '',
+    };
+  }
+
+  const match = EPISODE.exec(post?.title ?? '');
+  if (!match) return { series: null, episode: null, title: post?.title ?? '' };
+
+  return {
+    series: match[1].trim(),
+    episode: Number(match[2]),
+    title: match[3].trim(),
+  };
+};
+
+// The episodes of one guide, in reading order, so an episode can render its own
+// series navigation and the index can group by guide.
+export const seriesOf = (posts, series) =>
+  posts
+    .map(post => ({ post, ...splitTitle(post) }))
+    .filter(entry => entry.series && entry.series === series)
+    .sort((a, b) => (a.episode ?? 0) - (b.episode ?? 0));
+
+// Three surfaces on the index: the guides, grouped; the standalone articles;
+// and what the press has written. `filter` already carries the last distinction.
+export const groupPublications = posts => {
+  const written = posts.filter(post => post.filter !== 'press');
+
+  const guides = [];
+  const articles = [];
+
+  written.forEach(post => {
+    const { series } = splitTitle(post);
+    if (!series) return articles.push(post);
+
+    const guide = guides.find(entry => entry.series === series);
+    if (guide) return guide.episodes.push(post);
+
+    guides.push({ series, episodes: [post] });
+  });
+
+  guides.forEach(guide => {
+    guide.episodes = seriesOf(guide.episodes, guide.series).map(e => e.post);
+  });
+
+  return { guides, articles, press: posts.filter(p => p.filter === 'press') };
+};

--- a/libs/publications.js
+++ b/libs/publications.js
@@ -31,6 +31,17 @@ const projection = locale => {
 
 const PUBLISHED = '_type == "post" && dateTime(publishedAt) < dateTime(now())';
 
+// Whether the practice wrote this or was written about. `filter` is the field
+// the studio sets, and it is the answer when it is set; but it can be left
+// empty, and a document carrying the URL of someone else's article is not the
+// practice's own writing whatever the field says.
+//
+// Worth being sure about: this decides the section on the index, whether the
+// author block appears, and whether the structured data names Alice Ouaknine as
+// the author. Defaulting the other way publishes her as the author of Le Monde's
+// copy.
+export const isPress = post => post?.filter === 'press' || Boolean(post?.source);
+
 // Only what the reader can actually read. A French press cutting has no English
 // body, and listing it on the English site would be a link to an empty page.
 const readable = post => Boolean(post?.body?.length);
@@ -95,7 +106,7 @@ export const seriesOf = (posts, series) =>
 // Three surfaces on the index: the guides, grouped; the standalone articles;
 // and what the press has written. `filter` already carries the last distinction.
 export const groupPublications = posts => {
-  const written = posts.filter(post => post.filter !== 'press');
+  const written = posts.filter(post => !isPress(post));
 
   const guides = [];
   const articles = [];
@@ -114,5 +125,5 @@ export const groupPublications = posts => {
     guide.episodes = seriesOf(guide.episodes, guide.series).map(e => e.post);
   });
 
-  return { guides, articles, press: posts.filter(p => p.filter === 'press') };
+  return { guides, articles, press: posts.filter(isPress) };
 };

--- a/libs/publications.js
+++ b/libs/publications.js
@@ -20,12 +20,11 @@ const LOCALES = ['fr', 'en'];
 // two the site has rather than trusted from the route.
 const safeLocale = locale => (LOCALES.includes(locale) ? locale : 'fr');
 
-// One projection, with the body opt-in. Two near-identical copies drifted the
-// moment a field was added to one and not the other, and the body is the whole
-// document: projecting it into a list serialises every publication's full text
-// into the page's __NEXT_DATA__, which measured 227 kB on the index for content
-// it never renders.
-const projection = (locale, { body = false } = {}) => {
+// Everything but the prose. The body is the whole document, and projecting it
+// into a list serialised every publication's full text into the page's
+// __NEXT_DATA__: 227 kB on the index for content it never renders. The one page
+// that renders prose fetches it separately, by id, in `fetchPublicationBody`.
+const projection = locale => {
   const l = safeLocale(locale);
   const o = otherLocale(l);
 
@@ -40,7 +39,7 @@ const projection = (locale, { body = false } = {}) => {
     "episode": episode,
     "field": relatedExpertise->title,
     "title": coalesce(content${l}.title${l}, content${o}.title${o}),
-    "hasBody": defined(content${l}.body${l}),${body ? `\n    "body": content${l}.body${l},` : ''}
+    "hasBody": defined(content${l}.body${l}),
     "readingTime": round(length(pt::text(content${l}.body${l})) / 5 / 180)
   }`;
 };

--- a/libs/publications.js
+++ b/libs/publications.js
@@ -1,24 +1,31 @@
 import clientApi from './clientApi';
 import { slugify } from './slug';
+import { otherLocale, withSlug } from './publication-fields';
+
+// The pure derivations live next door so they can be loaded without a CMS
+// client. Re-exported here so call sites import one module.
+export {
+  formatDate,
+  groupPublications,
+  isPress,
+  otherLocale,
+  seriesOf,
+  splitTitle,
+} from './publication-fields';
 
 const LOCALES = ['fr', 'en'];
-
-export const otherLocale = locale => (locale === 'fr' ? 'en' : 'fr');
 
 // Portable text lives at content<locale>.body<locale>, which GROQ cannot reach
 // through a parameter, so the locale is interpolated. It is checked against the
 // two the site has rather than trusted from the route.
 const safeLocale = locale => (LOCALES.includes(locale) ? locale : 'fr');
 
-// Everything but the body. This is what a list needs, and a list is most of what
-// the section does: the index renders ten rows, the series rail renders links,
-// the sitemap renders slugs. Projecting the body into any of them serialises the
-// full text of every publication into the page's __NEXT_DATA__, which measured
-// 227 kB on the index for content it never renders.
-//
-// `hasBody` stands in for the body in the one place a list still needs it: a
-// piece is listed in a language only when it was written in that language.
-const metaProjection = locale => {
+// One projection, with the body opt-in. Two near-identical copies drifted the
+// moment a field was added to one and not the other, and the body is the whole
+// document: projecting it into a list serialises every publication's full text
+// into the page's __NEXT_DATA__, which measured 227 kB on the index for content
+// it never renders.
+const projection = (locale, { body = false } = {}) => {
   const l = safeLocale(locale);
   const o = otherLocale(l);
 
@@ -33,51 +40,26 @@ const metaProjection = locale => {
     "episode": episode,
     "field": relatedExpertise->title,
     "title": coalesce(content${l}.title${l}, content${o}.title${o}),
-    "hasBody": defined(content${l}.body${l}),
+    "hasBody": defined(content${l}.body${l}),${body ? `\n    "body": content${l}.body${l},` : ''}
     "readingTime": round(length(pt::text(content${l}.body${l})) / 5 / 180)
   }`;
 };
 
-// The one caller that actually renders prose asks for it explicitly.
-const bodyProjection = locale => {
-  const l = safeLocale(locale);
-  const o = otherLocale(l);
-
-  return `{
-    _id,
-    filter,
-    author,
-    source,
-    publishedAt,
-    "slug": coalesce(slug.current, contentfr.titlefr, contenten.titleen),
-    "series": series,
-    "episode": episode,
-    "field": relatedExpertise->title,
-    "title": coalesce(content${l}.title${l}, content${o}.title${o}),
-    "hasBody": defined(content${l}.body${l}),
-    "body": content${l}.body${l},
-    "readingTime": round(length(pt::text(content${l}.body${l})) / 5 / 180)
-  }`;
-};
-
-const PUBLISHED = '_type == "post" && dateTime(publishedAt) < dateTime(now())';
-
-// Whether the practice wrote this or was written about. `filter` is the field
-// the studio sets, and it is the answer when it is set; but it can be left
-// empty, and a document carrying the URL of someone else's article is not the
-// practice's own writing whatever the field says.
-//
-// Worth being sure about: this decides the section on the index, whether the
-// author block appears, and whether the structured data names Alice Ouaknine as
-// the author. Defaulting the other way publishes her as the author of Le Monde's
-// copy.
-export const isPress = post => post?.filter === 'press' || Boolean(post?.source);
+// A dated document that is not a draft. `publishedAt` is what holds a piece back
+// until its release date, so an undated one is not published at all.
+const PUBLISHED = `_type == "post"
+  && defined(publishedAt)
+  && dateTime(publishedAt) < dateTime(now())
+  && !(_id in path("drafts.**"))`;
 
 // Only what the reader can actually read. A French press cutting has no English
 // body, and listing it on the English site would be a link to an empty page.
 const readable = post => Boolean(post?.hasBody);
 
-const fetchWith = async (projection, locale) => {
+// Every publication in a language, without the prose. This is what a list needs,
+// and a list is most of what the section does: the index renders rows, the rail
+// renders links, the sitemap renders slugs.
+export const fetchPublications = async locale => {
   const posts = await clientApi.fetch(
     `*[${PUBLISHED}] | order(publishedAt desc) ${projection(locale)}`
   );
@@ -85,117 +67,36 @@ const fetchWith = async (projection, locale) => {
   return (posts ?? []).filter(readable).map(withSlug);
 };
 
-// Every publication in a language, without the prose. For lists, rails, sitemaps
-// and membership checks.
-export const fetchPublications = locale => fetchWith(metaProjection, locale);
+// One document's prose. The slug is derived in JS, so GROQ cannot filter on it;
+// the caller matches the slug against the body-free list it already holds and
+// passes the id. That way an unknown slug costs nothing beyond that list.
+export const fetchPublicationBody = async (locale, id) => {
+  const l = safeLocale(locale);
 
-// One publication, prose included. Fetched by slug rather than filtered out of
-// the whole corpus, so an unknown slug costs one query and not a full download.
-export const fetchPublication = async (locale, slug) => {
-  const posts = await fetchWith(bodyProjection, locale);
-  return posts.find(post => post.slug === slug) ?? null;
+  const post = await clientApi.fetch(
+    `*[${PUBLISHED} && _id == $id][0]{ "body": content${l}.body${l} }`,
+    { id }
+  );
+
+  return post?.body ?? null;
 };
 
-// The publication a legacy /articles/<id> URL was addressing. Looked up by id
-// directly: that path space is unbounded and attacker-chosen, so it must not
-// pull the corpus once per unknown id.
-export const fetchPublicationById = async id => {
+// The publication a legacy /articles/<id> URL was addressing, in the language
+// being read. It applies exactly the filters the destination page applies, so it
+// can never resolve an id to a page that will 404 — which is what a permanent
+// redirect to a locale with no body did.
+export const fetchPublicationById = async (locale, id) => {
+  const l = safeLocale(locale);
+
   const post = await clientApi.fetch(
-    `*[_type == "post" && _id == $id][0]{
+    `*[${PUBLISHED} && _id == $id][0]{
       "slug": coalesce(slug.current, contentfr.titlefr, contenten.titleen),
-      publishedAt
+      "hasBody": defined(content${l}.body${l})
     }`,
     { id }
   );
 
-  if (!post?.slug) return null;
-  if (post.publishedAt && new Date(post.publishedAt) > new Date()) return null;
+  if (!post?.slug || !post.hasBody) return null;
 
   return { slug: slugify(post.slug) };
-};
-
-// Formatting in the runtime's own zone renders one day on the server and another
-// in the browser for any evening timestamp: a hydration mismatch and a date off
-// by one. The practice is in Paris, so that is the zone the date means.
-export const formatDate = (iso, locale, options) =>
-  new Date(iso).toLocaleDateString(locale === 'en' ? 'en-GB' : 'fr-FR', {
-    timeZone: 'Europe/Paris',
-    ...options,
-  });
-
-// One slug for both languages, from the explicit field when the studio carries
-// one and from the French title otherwise. Deriving it from each locale's own
-// title would give the two versions different URLs, which is a 404 behind every
-// hreflang; sharing it makes a publication the same path in either language and
-// spares it the counterpart lookup a field of expertise needs.
-export const publicationSlug = post =>
-  slugify(post?.slug) || slugify(post?.title) || post?._id;
-
-const withSlug = post => ({ ...post, slug: publicationSlug(post) });
-
-// Until the studio carries series and episode as fields, an episode title holds
-// them in prose: "Guide de survie en garde à vue - Épisode 2 : Connaître …".
-//
-// The pattern is deliberately narrow. A standalone article whose title merely
-// contains a dash must come back whole rather than cut in half.
-const EPISODE = /^(.+?)\s*[–—-]\s*(?:Épisodes?|Episodes?|Ep\.?)\s*(\d+)\s*[:.]?\s*(.*)$/i;
-
-export const splitTitle = post => {
-  const raw = post?.title ?? '';
-  const match = EPISODE.exec(raw);
-
-  // The fields win when the studio carries them, but the title still has to be
-  // stripped: a document keeps its full "<Guide> - Épisode 1 : <subtitle>"
-  // title, so trusting the field alone would put the series name back into the
-  // heading the moment an editor filled the field the brief asks them to fill.
-  if (post?.series) {
-    return {
-      series: post.series,
-      episode: post.episode ?? (match ? Number(match[2]) : null),
-      title: (match ? match[3].trim() : raw) || raw,
-    };
-  }
-
-  if (!match) return { series: null, episode: null, title: raw };
-
-  // An episode with no subtitle after the number would otherwise leave an empty
-  // heading and a title tag reading " | Cabinet Ouaknine".
-  return {
-    series: match[1].trim(),
-    episode: Number(match[2]),
-    title: match[3].trim() || raw,
-  };
-};
-
-// The episodes of one guide, in reading order, so an episode can render its own
-// series navigation and the index can group by guide.
-export const seriesOf = (posts, series) =>
-  posts
-    .map(post => ({ post, ...splitTitle(post) }))
-    .filter(entry => entry.series && entry.series === series)
-    .sort((a, b) => (a.episode ?? 0) - (b.episode ?? 0));
-
-// Three surfaces on the index: the guides, grouped; the standalone articles;
-// and what the press has written. `filter` already carries the last distinction.
-export const groupPublications = posts => {
-  const written = posts.filter(post => !isPress(post));
-
-  const guides = [];
-  const articles = [];
-
-  written.forEach(post => {
-    const { series } = splitTitle(post);
-    if (!series) return articles.push(post);
-
-    const guide = guides.find(entry => entry.series === series);
-    if (guide) return guide.episodes.push(post);
-
-    guides.push({ series, episodes: [post] });
-  });
-
-  guides.forEach(guide => {
-    guide.episodes = seriesOf(guide.episodes, guide.series).map(e => e.post);
-  });
-
-  return { guides, articles, press: posts.filter(isPress) };
 };

--- a/libs/site.js
+++ b/libs/site.js
@@ -14,7 +14,17 @@ const FALLBACK = 'https://www.ouaknine-avocats.com';
 
 const parse = value => {
   try {
-    return new URL(value);
+    const url = new URL(value);
+
+    // Parseable is not enough. A non-special scheme parses perfectly well and
+    // yields the literal string "null" as its origin and an empty hostname, so
+    // the guard would pass and every canonical would read `null/contact`. Worse,
+    // an empty host is what every non-special scheme parses to, so a `javascript:`
+    // link would start resolving as a same-site path and walk straight past the
+    // external allowlist.
+    return url.protocol === 'https:' || url.protocol === 'http:'
+      ? url
+      : new URL(FALLBACK);
   } catch (err) {
     return new URL(FALLBACK);
   }
@@ -25,7 +35,14 @@ const url = parse(process.env.NEXT_PUBLIC_HOST || FALLBACK);
 // No trailing slash: every consumer concatenates a path onto it.
 export const SITE_URL = url.origin;
 
-// The two hosts this origin actually serves. A link to any other subdomain is
-// somewhere else, and `internalPath` returns a bare path, so calling one of them
-// internal would silently move the reader to the apex.
-export const SITE_HOSTS = [url.hostname, url.hostname.replace(/^www\./, '')];
+// The two spellings of this origin. Built from the apex rather than from
+// whichever form the env var happens to use, so the pair is the same either way:
+// deriving it as [hostname, hostname-without-www] gave two identical entries
+// when the var was already the apex, and quietly made every www URL external.
+//
+// Only these two. A link to any other subdomain is somewhere else, and
+// `internalPath` returns a bare path, so calling one internal would move the
+// reader to the apex without saying so.
+const apex = url.hostname.replace(/^www\./, '');
+
+export const SITE_HOSTS = [apex, `www.${apex}`];

--- a/libs/site.js
+++ b/libs/site.js
@@ -1,0 +1,31 @@
+// The site's own origin, in one place.
+//
+// This expression was written three times — in the head, in the sitemap and in
+// the link resolver — and the three drifted the moment one of them was fixed:
+// `??` only falls back on null and undefined, so a Vercel variable created and
+// left blank reaches the consumer as an empty string. One copy got `||`, the
+// other two did not.
+//
+// `||` so a blank falls back, and the parse is guarded because this is imported
+// at module scope by every page that renders CMS prose: a value without a scheme
+// would otherwise throw at import and take the site down rather than produce one
+// bad canonical.
+const FALLBACK = 'https://www.ouaknine-avocats.com';
+
+const parse = value => {
+  try {
+    return new URL(value);
+  } catch (err) {
+    return new URL(FALLBACK);
+  }
+};
+
+const url = parse(process.env.NEXT_PUBLIC_HOST || FALLBACK);
+
+// No trailing slash: every consumer concatenates a path onto it.
+export const SITE_URL = url.origin;
+
+// The two hosts this origin actually serves. A link to any other subdomain is
+// somewhere else, and `internalPath` returns a bare path, so calling one of them
+// internal would silently move the reader to the apex.
+export const SITE_HOSTS = [url.hostname, url.hostname.replace(/^www\./, '')];

--- a/libs/slug.js
+++ b/libs/slug.js
@@ -1,0 +1,11 @@
+// Sanity carries no slug on several document types, so URLs are derived from
+// the title. Shared so the derivation is identical everywhere: two slugifiers
+// that disagree by one character produce a 404 nobody can find.
+export const slugify = value =>
+  (value ?? '')
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');

--- a/libs/slug.js
+++ b/libs/slug.js
@@ -4,7 +4,7 @@
 export const slugify = value =>
   (value ?? '')
     .normalize('NFD')
-    .replace(/[̀-ͯ]/g, '')
+    .replace(/[\u0300-\u036f]/g, '')
     .toLowerCase()
     .trim()
     .replace(/[^a-z0-9]+/g, '-')

--- a/libs/slug.test.mjs
+++ b/libs/slug.test.mjs
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { slugify } from './slug.js';
+import { splitTitle, seriesOf, isPress } from './publication-fields.js';
+
+// slugify is the single derivation behind every publication URL, every field of
+// expertise URL, every hreflang and every @id in the JSON-LD graph. It has
+// already broken once on this branch: the combining-diacritic range was written
+// as two invisible literal characters instead of the escape, a diff no reviewer
+// can see. These pin the behaviour that regression changed.
+test('slugify strips accents', () => {
+  assert.equal(slugify('Droit pénal des affaires'), 'droit-penal-des-affaires');
+  assert.equal(slugify('Cyber-criminalité'), 'cyber-criminalite');
+  assert.equal(
+    slugify('Guide de survie en garde à vue - Épisode 1 : Connaître ses droits'),
+    'guide-de-survie-en-garde-a-vue-episode-1-connaitre-ses-droits'
+  );
+});
+
+test('slugify tolerates nothing', () => {
+  assert.equal(slugify(null), '');
+  assert.equal(slugify(undefined), '');
+  assert.equal(slugify(''), '');
+});
+
+// splitTitle feeds the h1, the title tag, the index grouping, the rail numbering
+// and the schema isPartOf. Its four quadrants are (series field) x (title match).
+test('splitTitle parses an episode title', () => {
+  assert.deepEqual(
+    splitTitle({ title: 'Guide de survie – Épisode 2 : Connaître les raisons' }),
+    { series: 'Guide de survie', episode: 2, title: 'Connaître les raisons' }
+  );
+});
+
+test('splitTitle still strips the title when the series field is set', () => {
+  assert.deepEqual(
+    splitTitle({
+      title: 'Guide de survie – Épisode 2 : Connaître les raisons',
+      series: 'Guide de survie',
+      episode: 2,
+    }),
+    { series: 'Guide de survie', episode: 2, title: 'Connaître les raisons' }
+  );
+});
+
+test('splitTitle leaves a standalone title whole', () => {
+  const title = 'Sapin II, article 17 - les huit piliers';
+  assert.deepEqual(splitTitle({ title }), {
+    series: null,
+    episode: null,
+    title,
+  });
+});
+
+test('splitTitle never yields an empty heading', () => {
+  const title = 'Guide de survie – Épisode 6';
+  assert.equal(splitTitle({ title }).title, title);
+  assert.equal(splitTitle({}).title, '');
+});
+
+test('seriesOf orders by episode, not by publication date', () => {
+  const posts = [
+    { _id: 'a', title: 'G – Épisode 1 : a', publishedAt: '2027-05-01' },
+    { _id: 'b', title: 'G – Épisode 2 : b', publishedAt: '2027-04-01' },
+    { _id: 'c', title: 'G – Épisode 3 : c', publishedAt: '2027-03-01' },
+  ];
+
+  assert.deepEqual(
+    seriesOf(posts, 'G').map(entry => entry.episode),
+    [1, 2, 3]
+  );
+});
+
+// Getting this wrong publishes Alice Ouaknine as the author of Le Monde's copy.
+test('a document carrying someone else\'s URL is press whatever filter says', () => {
+  assert.equal(isPress({ filter: 'press' }), true);
+  assert.equal(isPress({ source: 'https://lemonde.fr/x' }), true);
+  assert.equal(isPress({ filter: 'fact' }), false);
+  assert.equal(isPress({}), false);
+});

--- a/libs/slug.test.mjs
+++ b/libs/slug.test.mjs
@@ -90,6 +90,11 @@ test('internalPath keeps a same-site link on the site', () => {
   );
   assert.equal(internalPath('/publications/x'), '/publications/x');
   assert.equal(internalPath('#top'), '#top');
+  // The bare domain, which is what an editor gets by copying it.
+  assert.equal(
+    internalPath('https://ouaknine-avocats.com/publications/x'),
+    '/publications/x'
+  );
 });
 
 test('internalPath sends everything else away', () => {
@@ -99,6 +104,15 @@ test('internalPath sends everything else away', () => {
   assert.equal(internalPath('https://www.ouaknine-avocats.com@evil.com'), null);
   assert.equal(internalPath('https://notouaknine-avocats.com/x'), null);
   assert.equal(internalPath('javascript:alert(1)'), null);
+});
+
+test('internalPath never returns a protocol-relative path', () => {
+  // `new URL` resolves `..` before pathname is read, so these arrive as
+  // "//evil.com" unless the leading slashes are collapsed.
+  for (const href of ['/..//evil.com', '/.//evil.com', '/a/../..//evil.com']) {
+    const path = internalPath(href);
+    assert.ok(path === null || !path.startsWith('//'), `${href} -> ${path}`);
+  }
 });
 
 test('isSafeExternal refuses anything it does not recognise', () => {

--- a/libs/slug.test.mjs
+++ b/libs/slug.test.mjs
@@ -3,6 +3,7 @@ import { test } from 'node:test';
 
 import { slugify } from './slug.js';
 import { splitTitle, seriesOf, isPress } from './publication-fields.js';
+import { internalPath, isSafeExternal } from './href.js';
 
 // slugify is the single derivation behind every publication URL, every field of
 // expertise URL, every hreflang and every @id in the JSON-LD graph. It has
@@ -78,4 +79,34 @@ test('a document carrying someone else\'s URL is press whatever filter says', ()
   assert.equal(isPress({ source: 'https://lemonde.fr/x' }), true);
   assert.equal(isPress({ filter: 'fact' }), false);
   assert.equal(isPress({}), false);
+});
+
+// Link marks and `source` are free text an editor fills. Both decisions used to
+// be written twice and drifted; these pin the one that survived.
+test('internalPath keeps a same-site link on the site', () => {
+  assert.equal(
+    internalPath('https://www.ouaknine-avocats.com/articles/abc'),
+    '/articles/abc'
+  );
+  assert.equal(internalPath('/publications/x'), '/publications/x');
+  assert.equal(internalPath('#top'), '#top');
+});
+
+test('internalPath sends everything else away', () => {
+  assert.equal(internalPath('https://evil.com/'), null);
+  assert.equal(internalPath('//evil.com'), null);
+  assert.equal(internalPath('/\\evil.com'), null);
+  assert.equal(internalPath('https://www.ouaknine-avocats.com@evil.com'), null);
+  assert.equal(internalPath('https://notouaknine-avocats.com/x'), null);
+  assert.equal(internalPath('javascript:alert(1)'), null);
+});
+
+test('isSafeExternal refuses anything it does not recognise', () => {
+  assert.equal(isSafeExternal('https://lemonde.fr/x'), true);
+  assert.equal(isSafeExternal('mailto:a@b.c'), true);
+  assert.equal(isSafeExternal('javascript:alert(1)'), false);
+  assert.equal(isSafeExternal('  JAVASCRIPT:alert(1)'), false);
+  assert.equal(isSafeExternal('data:text/html,x'), false);
+  assert.equal(isSafeExternal(null), false);
+  assert.equal(isSafeExternal(undefined), false);
 });

--- a/libs/slug.test.mjs
+++ b/libs/slug.test.mjs
@@ -104,6 +104,9 @@ test('internalPath sends everything else away', () => {
   assert.equal(internalPath('https://www.ouaknine-avocats.com@evil.com'), null);
   assert.equal(internalPath('https://notouaknine-avocats.com/x'), null);
   assert.equal(internalPath('javascript:alert(1)'), null);
+  // A real subdomain is somewhere else. internalPath returns a bare path, so
+  // calling it internal would silently land the reader on the apex.
+  assert.equal(internalPath('https://blog.ouaknine-avocats.com/x'), null);
 });
 
 test('internalPath never returns a protocol-relative path', () => {

--- a/libs/slug.test.mjs
+++ b/libs/slug.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
+import { execFileSync } from 'node:child_process';
 
 import { slugify } from './slug.js';
 import { splitTitle, seriesOf, isPress } from './publication-fields.js';
@@ -126,4 +127,48 @@ test('isSafeExternal refuses anything it does not recognise', () => {
   assert.equal(isSafeExternal('data:text/html,x'), false);
   assert.equal(isSafeExternal(null), false);
   assert.equal(isSafeExternal(undefined), false);
+});
+
+// libs/site.js owns the origin behind every canonical, hreflang, sitemap loc and
+// @id, and it reads the environment at module scope — so this runs in a
+// subprocess with the variable set. Both cases below used to pass the guard: one
+// throws, the other parses to an opaque origin and is the silent half.
+test('a bad NEXT_PUBLIC_HOST falls back instead of poisoning every URL', () => {
+  const probe = `
+    import { SITE_URL, SITE_HOSTS } from './libs/site.js';
+    import { internalPath } from './libs/href.js';
+    process.stdout.write(JSON.stringify({
+      SITE_URL,
+      SITE_HOSTS,
+      js: internalPath('javascript:alert(1)'),
+    }));
+  `;
+
+  for (const bad of ['', 'ouaknine-avocats.com', 'mailto:a@b.c', 'javascript:1']) {
+    const out = execFileSync(process.execPath, ['--input-type=module', '-e', probe], {
+      env: { ...process.env, NEXT_PUBLIC_HOST: bad },
+      encoding: 'utf8',
+    });
+
+    const { SITE_URL, SITE_HOSTS, js } = JSON.parse(out);
+    assert.equal(SITE_URL, 'https://www.ouaknine-avocats.com', `SITE_URL for ${bad}`);
+    assert.deepEqual(SITE_HOSTS, ['ouaknine-avocats.com', 'www.ouaknine-avocats.com']);
+    assert.equal(js, null, `javascript: href must never be internal (${bad})`);
+  }
+});
+
+test('SITE_HOSTS is the same pair whichever spelling the env var uses', () => {
+  const probe = `
+    import { SITE_HOSTS } from './libs/site.js';
+    process.stdout.write(JSON.stringify(SITE_HOSTS));
+  `;
+
+  const pairs = ['https://ouaknine-avocats.com', 'https://www.ouaknine-avocats.com'].map(host =>
+    execFileSync(process.execPath, ['--input-type=module', '-e', probe], {
+      env: { ...process.env, NEXT_PUBLIC_HOST: host },
+      encoding: 'utf8',
+    })
+  );
+
+  assert.equal(pairs[0], pairs[1]);
 });

--- a/next.config.js
+++ b/next.config.js
@@ -14,14 +14,13 @@ const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
 
-  // The articles section was removed with the redesign. Sixteen of its URLs
-  // were still earning search traffic, so they are sent on rather than left to
-  // 404: the two list pages to the practice areas that replaced them, every
-  // article to the home page. Locale prefixes are matched by Next itself.
+  // The articles section is now /publications. Its list pages redirect here;
+  // an individual article is resolved by pages/articles/[id].jsx, which looks
+  // the post up and sends it to its own slug. Locale prefixes are matched by
+  // Next itself.
   async redirects() {
     return [
-      { source: '/articles', destination: '/expertise', permanent: true },
-      { source: '/articles/:id', destination: '/', permanent: true },
+      { source: '/articles', destination: '/publications', permanent: true },
     ];
   },
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint --dir pages --dir components --dir libs",
+    "lint": "next lint --dir pages --dir components --dir libs --dir hooks --dir context",
     "test": "node --test"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "node --test"
   },
   "dependencies": {
     "@heroicons/react": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "next lint --dir pages --dir components --dir libs",
     "test": "node --test"
   },
   "dependencies": {

--- a/pages/500.jsx
+++ b/pages/500.jsx
@@ -9,10 +9,12 @@ import classes from './404.module.scss';
 // lands and it should look like the rest of the site.
 function Page500() {
   const locale = useLocale();
+  // Guarded: this is the page that renders after something else has thrown.
+  const copy = CONTENT[locale] ?? CONTENT.fr;
 
   return (
     <div className={classes.container}>
-      <h1 className={classes.title}>{CONTENT[locale].body}</h1>
+      <h1 className={classes.title}>{copy.body}</h1>
     </div>
   );
 }

--- a/pages/500.jsx
+++ b/pages/500.jsx
@@ -1,0 +1,20 @@
+import CONTENT from '../content/500Content.json';
+import useLocale from '../hooks/useLocale';
+
+import classes from './404.module.scss';
+
+// Next's built-in 500 is English-only and injects its own body colours, which
+// paint white under the site's chrome. The publication routes rethrow a transient
+// CMS failure rather than caching a 404 over a live page, so this is where that
+// lands and it should look like the rest of the site.
+function Page500() {
+  const locale = useLocale();
+
+  return (
+    <div className={classes.container}>
+      <h1 className={classes.title}>{CONTENT[locale].body}</h1>
+    </div>
+  );
+}
+
+export default Page500;

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,15 +1,23 @@
 import NavContext from '../context/nav-context';
 import CookieContext from '../context/cookie-context';
+import LocalesContext from '../context/locales-context';
 import Layout from '../components/layout/layout';
 import '../styles/globals.scss';
 
 function MyApp({ Component, pageProps }) {
+  // A page that publishes an explicit alternate set knows which languages it has.
+  const locales = pageProps?.seo?.alternates
+    ? Object.keys(pageProps.seo.alternates)
+    : null;
+
   return (
     <CookieContext>
       <NavContext>
-        <Layout>
-          <Component {...pageProps} />
-        </Layout>
+        <LocalesContext value={locales}>
+          <Layout>
+            <Component {...pageProps} />
+          </Layout>
+        </LocalesContext>
       </NavContext>
     </CookieContext>
   );

--- a/pages/api/sitemap.js
+++ b/pages/api/sitemap.js
@@ -44,6 +44,16 @@ const expertisePairs = async () => {
   ]);
 };
 
+// French where there is a French version, and otherwise whatever the set does
+// have. Assuming French exists published an unprefixed URL for an
+// English-only publication, which is a page the site does not serve.
+const defaultHref = alternates => {
+  const [locale, path] =
+    alternates.find(([l]) => l === 'fr') ?? alternates[0];
+
+  return url(locale, path);
+};
+
 // One <url> per page per language, each carrying the alternates for the whole
 // set. Google wants the annotation to be reciprocal, and a sitemap is the one
 // place it can be stated for both languages at once.
@@ -59,7 +69,7 @@ const entry = (locale, path, alternates, lastmod) => `
           )}"/>`
       )
       .join('')}
-    <xhtml:link rel="alternate" hreflang="x-default" href="${url('fr', alternates[0][1])}"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="${defaultHref(alternates)}"/>
     <lastmod>${lastmod}</lastmod>
   </url>`;
 
@@ -93,7 +103,9 @@ export default async function handler(req, res) {
       )
     );
   } catch (err) {
-    // As above.
+    // The static pages are still worth serving, but a sitemap that quietly loses
+    // every publication is the kind of failure nobody notices for a month.
+    console.error('sitemap publications', err);
   }
 
   const sitemap = `<?xml version="1.0" encoding="UTF-8"?>

--- a/pages/api/sitemap.js
+++ b/pages/api/sitemap.js
@@ -82,7 +82,9 @@ export default async function handler(req, res) {
   try {
     sets = sets.concat(await expertisePairs());
   } catch (err) {
-    // The static pages are still worth serving without the CMS.
+    // The static pages are still worth serving without the CMS, but twenty
+    // expertise URLs vanishing quietly is the same failure as below.
+    console.error('sitemap expertise', err);
   }
 
   // A publication shares one slug across both languages, so it is the same path

--- a/pages/api/sitemap.js
+++ b/pages/api/sitemap.js
@@ -1,6 +1,7 @@
 import clientApi from '../../libs/clientApi';
 import { expertiseSlug } from '../../libs/expertise';
 import EXPERTISE_PAIRS from '../../libs/expertisePairs';
+import { fetchPublications } from '../../libs/publications';
 import { withLocale } from '../../libs/localePath';
 
 const HOST =
@@ -10,7 +11,7 @@ const LOCALES = ['fr', 'en'];
 
 // No '/expertise': it renders the first field and canonicalises onto it, so
 // listing it here would ask Google to index a URL the page disowns.
-const PAGES = ['/', '/contact', '/iska', '/legal'];
+const PAGES = ['/', '/contact', '/iska', '/legal', '/publications'];
 
 const escape = value =>
   value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
@@ -72,6 +73,27 @@ export default async function handler(req, res) {
     sets = sets.concat(await expertisePairs());
   } catch (err) {
     // The static pages are still worth serving without the CMS.
+  }
+
+  // A publication shares one slug across both languages, so it is the same path
+  // in either and needs no counterpart lookup. Only the languages it was
+  // actually written in are listed.
+  try {
+    const byLocale = await Promise.all(
+      LOCALES.map(async locale => [locale, await fetchPublications(locale)])
+    );
+
+    const slugs = new Set(byLocale.flatMap(([, posts]) => posts.map(p => p.slug)));
+
+    sets = sets.concat(
+      [...slugs].map(slug =>
+        byLocale
+          .filter(([, posts]) => posts.some(p => p.slug === slug))
+          .map(([locale]) => [locale, `/publications/${slug}`])
+      )
+    );
+  } catch (err) {
+    // As above.
   }
 
   const sitemap = `<?xml version="1.0" encoding="UTF-8"?>

--- a/pages/api/sitemap.js
+++ b/pages/api/sitemap.js
@@ -3,9 +3,9 @@ import { expertiseSlug } from '../../libs/expertise';
 import EXPERTISE_PAIRS from '../../libs/expertisePairs';
 import { fetchPublications } from '../../libs/publications';
 import { withLocale } from '../../libs/localePath';
+import { SITE_URL } from '../../libs/site';
 
-const HOST =
-  process.env.NEXT_PUBLIC_HOST ?? 'https://www.ouaknine-avocats.com';
+const HOST = SITE_URL;
 
 const LOCALES = ['fr', 'en'];
 

--- a/pages/articles/[id].jsx
+++ b/pages/articles/[id].jsx
@@ -36,14 +36,21 @@ export async function getServerSideProps({ params, locale, res }) {
     ? withLocale(resolved.locale, `/publications/${resolved.slug}`)
     : withLocale(locale, '/publications');
 
-  // Only a resolved post earns a permanent redirect. A CMS failure or an id with
-  // no readable publication behind it gets a temporary one, so the URL can still
-  // find its own page later rather than being pinned to the index for good.
-  const permanent = Boolean(resolved);
+  // Only a hit in the language being read is permanent. The cross-locale
+  // fallback is best-effort: /en/articles/<id> for a piece that is French-only
+  // today should serve /en/publications/<slug> once its English body is written,
+  // and a 308 would have consolidated it onto the French page for good.
+  const permanent = Boolean(resolved) && resolved.locale === locale;
 
-  if (permanent) {
-    res.setHeader('Cache-Control', 'public, max-age=0, s-maxage=3600');
-  }
+  // Both branches get an edge cache. Without one on the miss, an unbounded
+  // attacker-chosen path space reaches the origin on every request, and each
+  // miss now costs two CMS round trips.
+  res.setHeader(
+    'Cache-Control',
+    permanent
+      ? 'public, max-age=0, s-maxage=3600'
+      : 'public, max-age=0, s-maxage=60'
+  );
 
   return { redirect: { destination, permanent } };
 }

--- a/pages/articles/[id].jsx
+++ b/pages/articles/[id].jsx
@@ -10,9 +10,24 @@ export default function LegacyArticle() {
   return null;
 }
 
+// A Sanity document id. Anything else is not a legacy URL, and this route is the
+// site's only SSR path over an unbounded, attacker-chosen path space: without a
+// shape test every request is request-time CMS I/O.
+const DOCUMENT_ID = /^[A-Za-z0-9._-]{1,64}$/;
+
 export async function getServerSideProps({ params, locale, res }) {
   const twin = otherLocale(locale);
   let resolved = null;
+
+  if (!DOCUMENT_ID.test(params.id ?? '')) {
+    res.setHeader('Cache-Control', 'public, max-age=0, s-maxage=3600');
+    return {
+      redirect: {
+        destination: withLocale(locale, '/publications'),
+        permanent: false,
+      },
+    };
+  }
 
   try {
     // In the language being read when it exists there. The press cuttings are
@@ -27,7 +42,7 @@ export async function getServerSideProps({ params, locale, res }) {
       if (there) resolved = { locale: twin, slug: there.slug };
     }
   } catch (err) {
-    console.error('legacy article getServerSideProps', params.id, err);
+    console.error('legacy article getServerSideProps', locale, params.id, err);
   }
 
   // Next does not prefix a getServerSideProps redirect with the active locale,

--- a/pages/articles/[id].jsx
+++ b/pages/articles/[id].jsx
@@ -1,4 +1,4 @@
-import { fetchPublicationById } from '../../libs/publications';
+import { fetchPublicationById, otherLocale } from '../../libs/publications';
 import { withLocale } from '../../libs/localePath';
 
 // The articles section used to address a post by its Sanity id. Sixteen of those
@@ -11,28 +11,35 @@ export default function LegacyArticle() {
 }
 
 export async function getServerSideProps({ params, locale, res }) {
-  let post = null;
+  const twin = otherLocale(locale);
+  let resolved = null;
 
   try {
-    post = await fetchPublicationById(params.id);
+    // In the language being read when it exists there. The press cuttings are
+    // French only, so an English legacy URL for one has to cross over rather
+    // than land permanently on an English page that does not exist.
+    const here = await fetchPublicationById(locale, params.id);
+
+    if (here) {
+      resolved = { locale, slug: here.slug };
+    } else {
+      const there = await fetchPublicationById(twin, params.id);
+      if (there) resolved = { locale: twin, slug: there.slug };
+    }
   } catch (err) {
-    // Fall through to the index; the redirect below stays temporary so the real
-    // destination is still reachable once the CMS answers again.
+    console.error('legacy article getServerSideProps', params.id, err);
   }
 
   // Next does not prefix a getServerSideProps redirect with the active locale,
-  // so an unprefixed path sends every /en/articles/<id> to the French page. The
-  // English half of the guide is the most-seen URL the site has, and permanent
-  // is the one kind of mistake a browser and a search engine both keep.
-  const destination = withLocale(
-    locale,
-    post ? `/publications/${post.slug}` : '/publications'
-  );
+  // so an unprefixed path sends every /en/articles/<id> to the French page.
+  const destination = resolved
+    ? withLocale(resolved.locale, `/publications/${resolved.slug}`)
+    : withLocale(locale, '/publications');
 
-  // Only a resolved post earns a permanent redirect. A CMS failure or an id that
-  // is not published yet gets a temporary one, so the URL can still find its own
-  // page later rather than being pinned to the index for good.
-  const permanent = Boolean(post);
+  // Only a resolved post earns a permanent redirect. A CMS failure or an id with
+  // no readable publication behind it gets a temporary one, so the URL can still
+  // find its own page later rather than being pinned to the index for good.
+  const permanent = Boolean(resolved);
 
   if (permanent) {
     res.setHeader('Cache-Control', 'public, max-age=0, s-maxage=3600');

--- a/pages/articles/[id].jsx
+++ b/pages/articles/[id].jsx
@@ -1,0 +1,26 @@
+import { fetchPublications } from '../../libs/publications';
+
+// The articles section used to address a post by its Sanity id. Sixteen of those
+// URLs were still earning search traffic when the section was removed, and PR
+// #16 sent them to the home page for want of anywhere better. Now that the posts
+// render again, the id is resolved to the publication it belongs to rather than
+// mapped in a table that would go stale the first time a title changes.
+export default function LegacyArticle() {
+  return null;
+}
+
+export async function getServerSideProps({ params, locale, res }) {
+  let destination = '/publications';
+
+  try {
+    const posts = await fetchPublications(locale);
+    const post = posts.find(entry => entry._id === params.id);
+    if (post) destination = `/publications/${post.slug}`;
+  } catch (err) {
+    // The index is a good enough landing when the CMS is unreachable.
+  }
+
+  res.setHeader('Cache-Control', 'public, max-age=0, s-maxage=3600');
+
+  return { redirect: { destination, permanent: true } };
+}

--- a/pages/articles/[id].jsx
+++ b/pages/articles/[id].jsx
@@ -1,4 +1,5 @@
-import { fetchPublications } from '../../libs/publications';
+import { fetchPublicationById } from '../../libs/publications';
+import { withLocale } from '../../libs/localePath';
 
 // The articles section used to address a post by its Sanity id. Sixteen of those
 // URLs were still earning search traffic when the section was removed, and PR
@@ -10,17 +11,32 @@ export default function LegacyArticle() {
 }
 
 export async function getServerSideProps({ params, locale, res }) {
-  let destination = '/publications';
+  let post = null;
 
   try {
-    const posts = await fetchPublications(locale);
-    const post = posts.find(entry => entry._id === params.id);
-    if (post) destination = `/publications/${post.slug}`;
+    post = await fetchPublicationById(params.id);
   } catch (err) {
-    // The index is a good enough landing when the CMS is unreachable.
+    // Fall through to the index; the redirect below stays temporary so the real
+    // destination is still reachable once the CMS answers again.
   }
 
-  res.setHeader('Cache-Control', 'public, max-age=0, s-maxage=3600');
+  // Next does not prefix a getServerSideProps redirect with the active locale,
+  // so an unprefixed path sends every /en/articles/<id> to the French page. The
+  // English half of the guide is the most-seen URL the site has, and permanent
+  // is the one kind of mistake a browser and a search engine both keep.
+  const destination = withLocale(
+    locale,
+    post ? `/publications/${post.slug}` : '/publications'
+  );
 
-  return { redirect: { destination, permanent: true } };
+  // Only a resolved post earns a permanent redirect. A CMS failure or an id that
+  // is not published yet gets a temporary one, so the URL can still find its own
+  // page later rather than being pinned to the index for good.
+  const permanent = Boolean(post);
+
+  if (permanent) {
+    res.setHeader('Cache-Control', 'public, max-age=0, s-maxage=3600');
+  }
+
+  return { redirect: { destination, permanent } };
 }

--- a/pages/contact.jsx
+++ b/pages/contact.jsx
@@ -11,8 +11,6 @@ import PageTitle from '../components/layout/page-title';
 import Image from 'next/image';
 import parisMap from '../public/images/paris-map.svg';
 
-const MAPS_URL =
-  'https://www.google.com/maps/place/Ouaknine+Alice+Avocat/@48.876648,2.3255411,14.2z/data=!4m5!3m4!1s0x0:0x51a276d4dfa05806!8m2!3d48.8775684!4d2.316890';
 
 function Contact({ data }) {
   const { titleseo, descriptionseo, title } = data;
@@ -34,7 +32,7 @@ function Contact({ data }) {
         <div className={classes.grid}>
           <a
             className={classes.map}
-            href={MAPS_URL}
+            href={footerContent.mapsUrl}
             target='_blank'
             rel='noreferrer'
             tabIndex={-1}
@@ -51,7 +49,7 @@ function Contact({ data }) {
               <dd className={classes.rowvalue}>
                 <a
                   className={classes.rowlink}
-                  href={MAPS_URL}
+                  href={footerContent.mapsUrl}
                   target='_blank'
                   rel='noreferrer'
                 >

--- a/pages/publications/[slug].jsx
+++ b/pages/publications/[slug].jsx
@@ -1,6 +1,6 @@
 import PublicationPage from '../../components/layout/publication-page';
 import {
-  fetchPublication,
+  fetchPublicationBody,
   fetchPublications,
   otherLocale,
   seriesOf,
@@ -36,17 +36,28 @@ export async function getStaticProps({ params, locale }) {
   try {
     const twin = otherLocale(locale);
 
-    // Only this page renders prose, so only this page asks for it. The list and
-    // the twin-locale check take the body-free projection: carrying bodies into
-    // them put the whole guide's text into the page's __NEXT_DATA__.
-    const [post, posts, translations] = await Promise.all([
-      fetchPublication(locale, params.slug),
+    // The list decides whether the page exists, so nothing heavier runs until it
+    // says yes. The twin-locale list only chooses whether an hreflang alternate
+    // is emitted, and a missing alternate is recoverable; a cached 404 is not,
+    // so it must not be able to take the page down with it.
+    const [posts, translations] = await Promise.all([
       fetchPublications(locale),
-      fetchPublications(twin),
+      fetchPublications(twin).catch(err => {
+        console.error('publication twin locale', params.slug, err);
+        return [];
+      }),
     ]);
 
-    if (!post) return { notFound: true, revalidate: 60 };
+    const meta = posts.find(entry => entry.slug === params.slug);
 
+    if (!meta) return { notFound: true, revalidate: 60 };
+
+    // Only now, and only this one document's prose.
+    const body = await fetchPublicationBody(locale, meta._id);
+
+    if (!body) return { notFound: true, revalidate: 60 };
+
+    const post = { ...meta, body };
     const { series, title } = splitTitle(post);
     const org = organizationContent[locale] ?? organizationContent.fr;
 

--- a/pages/publications/[slug].jsx
+++ b/pages/publications/[slug].jsx
@@ -45,7 +45,7 @@ export async function getStaticProps({ params, locale }) {
     const [posts, translations] = await Promise.all([
       fetchPublications(locale),
       fetchPublications(twin).catch(err => {
-        console.error('publication twin locale', params.slug, err);
+        console.error('publication twin locale', twin, params.slug, err);
         return [];
       }),
     ]);
@@ -99,7 +99,7 @@ export async function getStaticProps({ params, locale }) {
     // so Next caches it over the last good render; a thrown getStaticProps makes
     // it re-set the existing page instead (response-cache/index.js). The two
     // guards above are the only definitive absences.
-    console.error('publication getStaticProps', params.slug, err);
+    console.error('publication getStaticProps', locale, params.slug, err);
     throw err;
   }
 }

--- a/pages/publications/[slug].jsx
+++ b/pages/publications/[slug].jsx
@@ -1,0 +1,74 @@
+import PublicationPage from '../../components/layout/publication-page';
+import {
+  fetchPublications,
+  otherLocale,
+  seriesOf,
+  splitTitle,
+} from '../../libs/publications';
+import { plainText } from '../../libs/expertise';
+import { withLocale } from '../../libs/localePath';
+import organizationContent from '../../content/organizationContent.json';
+
+export default PublicationPage;
+
+export async function getStaticPaths({ locales }) {
+  try {
+    const lists = await Promise.all(
+      locales.map(async locale => ({
+        locale,
+        posts: await fetchPublications(locale),
+      }))
+    );
+
+    const paths = lists.flatMap(({ locale, posts }) =>
+      posts.map(post => ({ params: { slug: post.slug }, locale }))
+    );
+
+    return { paths, fallback: 'blocking' };
+  } catch (err) {
+    // A publication added in the studio still resolves on its first request.
+    return { paths: [], fallback: 'blocking' };
+  }
+}
+
+export async function getStaticProps({ params, locale }) {
+  try {
+    const twin = otherLocale(locale);
+
+    const [posts, translations] = await Promise.all([
+      fetchPublications(locale),
+      fetchPublications(twin),
+    ]);
+
+    const post = posts.find(entry => entry.slug === params.slug);
+
+    if (!post) return { notFound: true, revalidate: 60 };
+
+    const { series, title } = splitTitle(post);
+    const org = organizationContent[locale] ?? organizationContent.fr;
+
+    // A press cutting exists only in French. Annotating it as available in
+    // English would publish an hreflang to a page that is not there.
+    const path = `/publications/${post.slug}`;
+    const alternates = { [locale]: withLocale(locale, path) };
+
+    if (translations.some(entry => entry.slug === post.slug)) {
+      alternates[twin] = withLocale(twin, path);
+    }
+
+    return {
+      props: {
+        post,
+        series: series ? seriesOf(posts, series) : null,
+        seo: {
+          title: `${title} | ${org.name}`,
+          description: plainText(post.body),
+          alternates,
+        },
+      },
+      revalidate: 60,
+    };
+  } catch (err) {
+    return { notFound: true };
+  }
+}

--- a/pages/publications/[slug].jsx
+++ b/pages/publications/[slug].jsx
@@ -1,5 +1,6 @@
 import PublicationPage from '../../components/layout/publication-page';
 import {
+  fetchPublication,
   fetchPublications,
   otherLocale,
   seriesOf,
@@ -35,12 +36,14 @@ export async function getStaticProps({ params, locale }) {
   try {
     const twin = otherLocale(locale);
 
-    const [posts, translations] = await Promise.all([
+    // Only this page renders prose, so only this page asks for it. The list and
+    // the twin-locale check take the body-free projection: carrying bodies into
+    // them put the whole guide's text into the page's __NEXT_DATA__.
+    const [post, posts, translations] = await Promise.all([
+      fetchPublication(locale, params.slug),
       fetchPublications(locale),
       fetchPublications(twin),
     ]);
-
-    const post = posts.find(entry => entry.slug === params.slug);
 
     if (!post) return { notFound: true, revalidate: 60 };
 
@@ -56,10 +59,20 @@ export async function getStaticProps({ params, locale }) {
       alternates[twin] = withLocale(twin, path);
     }
 
+    // The rail and the pager render a number, a title and a link. Handing them
+    // whole documents would serialise every episode of the guide into the page.
+    const episodes = series
+      ? seriesOf(posts, series).map(entry => ({
+          post: { _id: entry.post._id, slug: entry.post.slug },
+          episode: entry.episode,
+          title: entry.title,
+        }))
+      : null;
+
     return {
       props: {
         post,
-        series: series ? seriesOf(posts, series) : null,
+        series: episodes,
         seo: {
           title: `${title} | ${org.name}`,
           description: plainText(post.body),
@@ -69,6 +82,9 @@ export async function getStaticProps({ params, locale }) {
       revalidate: 60,
     };
   } catch (err) {
-    return { notFound: true };
+    // A transient CMS failure must not cache a 404 for a live publication until
+    // the next deploy; the deliberate not-found above already carries a window.
+    console.error('publication getStaticProps', params.slug, err);
+    return { notFound: true, revalidate: 60 };
   }
 }

--- a/pages/publications/[slug].jsx
+++ b/pages/publications/[slug].jsx
@@ -27,7 +27,9 @@ export async function getStaticPaths({ locales }) {
 
     return { paths, fallback: 'blocking' };
   } catch (err) {
-    // A publication added in the studio still resolves on its first request.
+    // A publication added in the studio still resolves on its first request, but
+    // prebuilding none of them is a degradation worth recording.
+    console.error('publication getStaticPaths', err);
     return { paths: [], fallback: 'blocking' };
   }
 }
@@ -93,9 +95,11 @@ export async function getStaticProps({ params, locale }) {
       revalidate: 60,
     };
   } catch (err) {
-    // A transient CMS failure must not cache a 404 for a live publication until
-    // the next deploy; the deliberate not-found above already carries a window.
+    // Rethrown, not turned into a not-found. `notFound` is a successful result,
+    // so Next caches it over the last good render; a thrown getStaticProps makes
+    // it re-set the existing page instead (response-cache/index.js). The two
+    // guards above are the only definitive absences.
     console.error('publication getStaticProps', params.slug, err);
-    return { notFound: true, revalidate: 60 };
+    throw err;
   }
 }

--- a/pages/publications/index.jsx
+++ b/pages/publications/index.jsx
@@ -1,0 +1,34 @@
+import PublicationsIndex from '../../components/layout/publications-index';
+import clientApi from '../../libs/clientApi';
+import { fetchPublications } from '../../libs/publications';
+
+export default PublicationsIndex;
+
+const PAGE_QUERY = `*[_type == "articles" && language == $locale][0]{
+  titleseo,
+  descriptionseo,
+  title
+}`;
+
+export async function getStaticProps({ locale }) {
+  try {
+    const [content, posts] = await Promise.all([
+      clientApi.fetch(PAGE_QUERY, { locale: locale ?? 'fr' }),
+      fetchPublications(locale),
+    ]);
+
+    return {
+      props: {
+        data: content ?? {},
+        posts,
+        seo: {
+          title: content?.titleseo ?? '',
+          description: content?.descriptionseo ?? '',
+        },
+      },
+      revalidate: 60,
+    };
+  } catch (err) {
+    return { notFound: true };
+  }
+}

--- a/pages/publications/index.jsx
+++ b/pages/publications/index.jsx
@@ -1,6 +1,7 @@
 import PublicationsIndex from '../../components/layout/publications-index';
 import clientApi from '../../libs/clientApi';
 import { fetchPublications } from '../../libs/publications';
+import publicationsContent from '../../content/publicationsContent.json';
 
 export default PublicationsIndex;
 
@@ -16,18 +17,23 @@ export async function getStaticProps({ locale }) {
       // The page renders without its CMS copy (`content ?? {}` below); only a
       // failure to fetch the posts genuinely leaves it with nothing.
       clientApi.fetch(PAGE_QUERY, { locale: locale ?? 'fr' }).catch(err => {
-        console.error('publications index copy', err);
+        console.error('publications index copy', locale, err);
         return null;
       }),
       fetchPublications(locale),
     ]);
 
+    // The copy query is allowed to fail, so it must have somewhere to fall back
+    // to: `{}` rendered an empty h1 and an empty title tag on a route that is
+    // both a nav item and a sitemap entry.
+    const copy = publicationsContent[locale] ?? publicationsContent.fr;
+
     return {
       props: {
-        data: content ?? {},
+        data: { ...content, title: content?.title || copy.title },
         posts,
         seo: {
-          title: content?.titleseo ?? '',
+          title: content?.titleseo || copy.title,
           description: content?.descriptionseo ?? '',
         },
       },
@@ -37,7 +43,7 @@ export async function getStaticProps({ locale }) {
     // Rethrown rather than turned into a not-found: this route is a nav item and
     // a sitemap entry, and a returned `notFound` would cache a 404 over the last
     // good render instead of leaving it up.
-    console.error('publications index getStaticProps', err);
+    console.error('publications index getStaticProps', locale, err);
     throw err;
   }
 }

--- a/pages/publications/index.jsx
+++ b/pages/publications/index.jsx
@@ -13,7 +13,12 @@ const PAGE_QUERY = `*[_type == "articles" && language == $locale][0]{
 export async function getStaticProps({ locale }) {
   try {
     const [content, posts] = await Promise.all([
-      clientApi.fetch(PAGE_QUERY, { locale: locale ?? 'fr' }),
+      // The page renders without its CMS copy (`content ?? {}` below); only a
+      // failure to fetch the posts genuinely leaves it with nothing.
+      clientApi.fetch(PAGE_QUERY, { locale: locale ?? 'fr' }).catch(err => {
+        console.error('publications index copy', err);
+        return null;
+      }),
       fetchPublications(locale),
     ]);
 

--- a/pages/publications/index.jsx
+++ b/pages/publications/index.jsx
@@ -34,9 +34,10 @@ export async function getStaticProps({ locale }) {
       revalidate: 60,
     };
   } catch (err) {
-    // Without a revalidate window Next caches the 404 until the next deploy, and
-    // this route is both a nav item and a sitemap entry.
+    // Rethrown rather than turned into a not-found: this route is a nav item and
+    // a sitemap entry, and a returned `notFound` would cache a 404 over the last
+    // good render instead of leaving it up.
     console.error('publications index getStaticProps', err);
-    return { notFound: true, revalidate: 60 };
+    throw err;
   }
 }

--- a/pages/publications/index.jsx
+++ b/pages/publications/index.jsx
@@ -29,6 +29,9 @@ export async function getStaticProps({ locale }) {
       revalidate: 60,
     };
   } catch (err) {
-    return { notFound: true };
+    // Without a revalidate window Next caches the 404 until the next deploy, and
+    // this route is both a nav item and a sitemap entry.
+    console.error('publications index getStaticProps', err);
+    return { notFound: true, revalidate: 60 };
   }
 }


### PR DESCRIPTION
## Motivation

The redesign removed the articles surface (`ccce6a4`) but deliberately left the Sanity documents in place. Those ten documents were **31% of the site's clicks and 57% of its impressions** over the last twelve months, and none of them was reachable.

Five are the *Guide de survie en garde à vue*: bilingual pieces written by Alice Ouaknine, **4,602 French words, more than twice the entire expertise section** (1,850 words across ten pages). Episode 1 alone held **position 6.7 on 12,791 impressions** — more impressions than the home page, at a third of the position. It is the only thing on this domain that has ever ranked on page one.

The other five are press mentions from Le Monde, le JDD, le Parisien, BFM TV and le Dauphiné Libéré. For a lawyer's site, where Google applies its harshest quality bar, that kind of outside corroboration is exactly what it weighs, and it was sitting unrendered.

PR #16 had to send all sixteen of those URLs to the home page because there was nowhere better for them to go.

## Solution

**`/publications`**, both locales, rendering the existing documents. No new content required.

- **A guide groups itself.** The index reads the series out of the episode titles and lists episodes 01–05 in order under a Bodoni section head. An episode carries the rest of its guide in the sticky rail the fields of expertise already use, so nothing new enters the design vocabulary.
- **Three surfaces** — guides, standalone articles, and *Le cabinet dans la presse* — driven by the `filter` field that was already on the documents.
- **URLs are the title, not the Sanity id.** `/publications/guide-de-survie-en-garde-a-vue-episode-1-connaitre-ses-droits` rather than `/articles/c320d229-c35d-416c-b1d2-b9eb082937ba`.
- **The old ids still resolve.** `pages/articles/[id].jsx` looks the post up and 301s to its own slug, rather than a hardcoded table that would go stale the first time a title changed. Unknown ids fall back to the index. That replaces the blunt redirect from #16, so the episode that was at position 6.7 has a real destination again.
- **Structured data attaches to the graph rather than restating it**: an `Article` authored by the `Person` node carrying both bar admissions, published by the practice, `isPartOf` its series, `about` the `Service` node for its field. A press cutting is a `NewsArticle` that *mentions* the practice — not something it wrote, and with no author claim.
- **On mobile the rail moves below the article.** Stacked, it would put five links between the title and the first sentence; an article is read before it is navigated.

### Two bugs found while implementing

- **Every hreflang on a publication pointed at a 404.** The slug was derived from each locale's own title, so the French and English versions of the same piece got different URLs. Both languages now share one slug, which also makes a publication the same path in either language and spares it the counterpart lookup a field of expertise needs.
- **French-only press cuttings claimed an English version.** A piece is now annotated as available in a language only when it was actually written in that language.

### Also in here

- **The Google Maps URL was hardcoded twice, with two different sets of coordinates, both pointing at the previous office** in the 7th. One value in `footerContent.json` now, taken from the live Google listing (which has the correct 75009 address), and the schema carries `geo` and `hasMap` from it. This is the debt `CLAUDE.md` already flagged.
- **`RichText` opened every link in a new tab, including internal ones.** The guide cross-links its own episodes in prose, so sending a reader to a new tab to read the next one was wrong.
- The slugifier moves to `libs/slug.js`. Two that disagree by one character produce a 404 nobody can find.
- **`docs/publications-editorial-brief.md`** — the house format reverse-engineered from the guide that ranked, the déontologie constraints (secret professionnel, the advertising rules, no AI-generated legal content), the 45-piece list for pénal des affaires and enquêtes internes, and a fifteen-month release schedule. **Every piece must state the role of the lawyer**; the brief says how, and how not to. Linked from `CLAUDE.md`.

## Verification

Against a clean production build on `next start`:

- **17 pages checked, 21 unique canonical and hreflang targets, all 200.** Before the slug fix, every English publication URL was a 404.
- **Sitemap: 45 URLs (up from 28), 15 of them publications, zero non-reciprocal alternates**, validated by parsing the XML.
- Legacy ids resolve to their new slugs; unknown ids fall back to the index; `/articles` → `/publications`; `/nope` and unknown slugs 404 properly.
- JSON-LD parses on every page type.
- Screenshotted at 1440 and at a true 390px viewport.
- `yarn lint` clean, `yarn build` compiles.

## What this does not do

It publishes nothing new. The section renders what is already in Sanity; the 45 pieces in the brief are the firm's to write, starting October 2026 per the schedule. The index page title still reads "Les articles du Cabinet" because it comes from the CMS — renaming it to "Publications" is a Sanity edit, as are the four fields the brief asks for (`slug`, `series`, `episode`, `relatedExpertise`). Everything degrades gracefully without them, which is why it renders today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)