### PR TITLE
chore: register the Sanity remote MCP server at project scope

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "sanity": {
+      "type": "http",
+      "url": "https://mcp.sanity.io/mcp"
+    }
+  }
+}


### PR DESCRIPTION
## Motivation

The site's page copy lives in Sanity, so anyone working in this repo needs a way to read and edit those documents without leaving the editor. Sanity's local `@sanity/mcp-server` npm package is now deprecated in favour of the hosted server at `mcp.sanity.io`, and it required handing an `sk...` write token to the agent.

## Solution

Adds a project-scoped `.mcp.json` registering the remote Sanity MCP server over HTTP, so every clone and Conductor workspace picks it up. Auth is per-user OAuth handled by Claude Code, so no credentials land in the repo; each collaborator approves the server once and runs `/mcp` to authenticate.