### PR TITLE
refactor: reach Sanity directly, and lift the Next 16 version cap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,6 +226,23 @@ déontologie constraints, the full article list and the release schedule.
 
 ## Content: two sources, know which is which
 
+**Sanity** is reached through `@sanity/client` and `@sanity/image-url` directly.
+The `next-sanity` and `next-sanity-image` wrappers were dropped: each re-exported
+one function, and between them they pinned the repo below Next 16. On the version
+pinned here the client constructor is the *default* export, not `createClient`,
+which arrives in v4. `libs/clientApi.ts` also exports `SANITY_PROJECT`, so the
+image URL builder takes a plain `{ projectId, dataset }` rather than reaching
+into the client for its private `clientConfig` — that coupling is what forced a
+new major of `@sanity/image-url`, and it is what would break on the next client
+bump.
+
+`components/ui/sanityImage.tsx` reproduces what `useNextSanityImage` did by
+default: `auto=format`, `fit=clip`, quality 75, a loader that resizes on Sanity's
+CDN rather than through `/_next/image`, and a 64px blur-up placeholder at quality
+30. The intrinsic size comes from the asset reference itself
+(`image-<id>-<w>x<h>-<ext>`), parsed by `libs/sanity-image.ts`; without it
+`next/image` cannot reserve the space and a responsive layout collapses.
+
 **Sanity** (`libs/clientApi.ts`) holds page copy — titles, body rich text, the
 expertise list. Editable by the client. No page component contains GROQ: the
 queries live in `libs/page-content.ts` and `libs/expertise.ts`, which every
@@ -456,6 +473,10 @@ call button). Adding a fourth should need a reason.
 - `content/publicationsContent.json` carries no `description`, so the markdown
   representation of `/publications` publishes a title and its lists with no
   blockquote lead. Every other page has one.
+- No published document currently embeds a CMS image, so
+  `components/ui/sanityImage.tsx` is unexercised in production. It is covered by
+  the reference parser's tests, a component test for the size and alt reaching
+  the DOM, and a manual check that all three CDN URLs it builds resolve.
 - `libs/types.ts` describes the CMS documents by hand rather than parsing them.
   The GROQ projections are the contract, and nothing validates that a document
   matches the type at the boundary; a studio schema change is caught by a

--- a/components/ui/rich-text.test.tsx
+++ b/components/ui/rich-text.test.tsx
@@ -93,3 +93,50 @@ test("nothing to render is nothing, not an empty shell", () => {
 
 	expect(container).toBeEmptyDOMElement();
 });
+
+test("an image block renders at the size encoded in its reference", () => {
+	// The GROQ projections return a bare asset reference, so the reference is
+	// where the intrinsic size comes from. Without it the article reflows
+	// around each image as it arrives.
+	render(
+		<RichText
+			value={[
+				{
+					_type: "image",
+					_key: "i",
+					alt: "Le palais de justice",
+					asset: { _ref: "image-abc123-1200x800-jpg", _type: "reference" },
+				},
+			]}
+		/>,
+	);
+
+	const img = screen.getByRole("img");
+	expect(img).toHaveAttribute("alt", "Le palais de justice");
+	expect(img).toHaveAttribute("width", "1200");
+	expect(img).toHaveAttribute("height", "800");
+});
+
+test("an image the studio left without alt text is marked decorative", () => {
+	// An empty alt is the right fallback. The attribute this component used to
+	// omit entirely is the wrong one: a screen reader falls back to the URL.
+	render(
+		<RichText
+			value={[
+				{
+					_type: "image",
+					_key: "i",
+					asset: { _ref: "image-abc123-1200x800-jpg", _type: "reference" },
+				},
+			]}
+		/>,
+	);
+
+	expect(screen.getByRole("presentation", { hidden: true })).toHaveAttribute("alt", "");
+});
+
+test("an image block with no asset renders nothing", () => {
+	const { container } = render(<RichText value={[{ _type: "image", _key: "i" }]} />);
+
+	expect(container.querySelector("img")).toBeNull();
+});

--- a/components/ui/rich-text.tsx
+++ b/components/ui/rich-text.tsx
@@ -55,10 +55,14 @@ export default function RichText({
 					),
 				},
 				types: {
-					image: ({ value: image }: { value: { asset?: SanityImageRef } }) =>
+					// The alt text sits on the block, not on the asset. The studio does not
+					// always fill it, and an empty string marks the image decorative, which
+					// is the right fallback and better than the attribute this component
+					// used to omit entirely.
+					image: ({ value: image }: { value: { asset?: SanityImageRef; alt?: string } }) =>
 						image.asset ? (
 							<div className={classes.img}>
-								<SanityImage asset={image.asset} />
+								<SanityImage asset={image.asset} alt={image.alt ?? ""} />
 							</div>
 						) : null,
 				},

--- a/components/ui/sanityImage.tsx
+++ b/components/ui/sanityImage.tsx
@@ -1,18 +1,56 @@
+import imageUrlBuilder from "@sanity/image-url";
+import type { ImageLoader } from "next/image";
 import Image from "next/image";
-import { useNextSanityImage } from "next-sanity-image";
 
-import clientApi from "../../libs/clientApi";
+import { SANITY_PROJECT } from "../../libs/clientApi";
+import { imageDimensions } from "../../libs/sanity-image";
 import type { SanityImageRef } from "../../libs/types";
 
-const SanityImage = ({ asset }: { asset: SanityImageRef }) => {
-	const imageProps = useNextSanityImage(clientApi, asset);
+// The transforms `next-sanity-image` applied by default, kept so the CDN keeps
+// serving the same bytes for the same request.
+const QUALITY = 75;
+const BLUR_WIDTH = 64;
+const BLUR_QUALITY = 30;
+const BLUR_AMOUNT = 50;
 
-	if (!imageProps) return null;
+const builder = imageUrlBuilder(SANITY_PROJECT);
+
+// `fit: clip` never enlarges past the asset, and `auto: format` lets Sanity
+// negotiate webp or avif per request. Resizing happens on Sanity's CDN rather
+// than through /_next/image, which is what the loader below is for.
+// biome-ignore lint/suspicious/noFocusedTests: `fit` here is the Sanity image builder's crop mode, not Jasmine's focused test.
+const source = (ref: string) => builder.image(ref).auto("format").fit("clip");
+
+const SanityImage = ({ asset, alt }: { asset: SanityImageRef; alt: string }) => {
+	const dimensions = imageDimensions(asset._ref);
+
+	// An image block the studio left without an asset, or a reference to
+	// something that is not an image: there is no size to reserve, so nothing
+	// to render.
+	if (!dimensions) return null;
+
+	const loader: ImageLoader = ({ width, quality }) =>
+		source(asset._ref)
+			.quality(quality || QUALITY)
+			.width(width)
+			.url();
 
 	return (
-		// No alt here: it belongs to the Portable Text block rather than to the
-		// asset, and the studio does not always fill it.
-		<Image {...imageProps} layout="responsive" sizes="(max-width: 800px) 100vw, 800px" />
+		<Image
+			loader={loader}
+			src={source(asset._ref).quality(QUALITY).url()}
+			width={dimensions.width}
+			height={dimensions.height}
+			alt={alt}
+			placeholder="blur"
+			blurDataURL={source(asset._ref)
+				.width(BLUR_WIDTH)
+				.quality(BLUR_QUALITY)
+				.blur(BLUR_AMOUNT)
+				.url()}
+			layout="responsive"
+			sizes="(max-width: 800px) 100vw, 800px"
+		/>
 	);
 };
 

--- a/libs/clientApi.ts
+++ b/libs/clientApi.ts
@@ -1,8 +1,27 @@
-import { createClient } from "next-sanity";
+import SanityClient from "@sanity/client";
 
-const clientApi = createClient({
-	projectId: process.env.NEXT_PUBLIC_SANITY_ID,
+// `@sanity/client` directly, not through `next-sanity`. That wrapper re-exported
+// one function; its current release peers on Next 16 with React 19, while
+// `next-sanity-image` capped the other end at Next 15. Between them they pinned
+// this repo to a version of Next it has outgrown.
+//
+// `createClient` is a named export from v4 onwards. On the version pinned here
+// the constructor is the default export, and it may be called without `new`.
+
+// The two fields that address a project on the CDN. Exported so the image URL
+// builder can take them straight, rather than reaching into the client for its
+// private `clientConfig` — which is the coupling that forced a new major of
+// @sanity/image-url, and the thing that would break on the next client bump.
+// An absent id stays absent rather than becoming a silent default: the client
+// refuses a blank one with "Configuration must contain `projectId`", which is
+// the error the local-development notes in CLAUDE.md tell you to expect.
+export const SANITY_PROJECT = {
+	projectId: process.env.NEXT_PUBLIC_SANITY_ID ?? "",
 	dataset: "production",
+};
+
+const clientApi = SanityClient({
+	...SANITY_PROJECT,
 	apiVersion: "2022-03-25",
 	useCdn: true,
 });

--- a/libs/sanity-image.test.ts
+++ b/libs/sanity-image.test.ts
@@ -1,0 +1,59 @@
+import { imageDimensions } from "./sanity-image";
+
+// The intrinsic size is the only thing `next/image` cannot work out for itself
+// here: the GROQ projections return a bare `asset._ref`, so the reference is
+// the sole source. Read it wrong and every image in an article renders at zero
+// height, or the page reflows around each one as it arrives.
+
+test("the dimensions come out of the reference", () => {
+	expect(imageDimensions("image-a1b2c3d4e5f6-1200x800-jpg")).toStrictEqual({
+		width: 1200,
+		height: 800,
+	});
+	expect(imageDimensions("image-abc-64x64-png")).toStrictEqual({ width: 64, height: 64 });
+	expect(imageDimensions("image-abc-3000x1687-webp")).toStrictEqual({
+		width: 3000,
+		height: 1687,
+	});
+});
+
+test("a reference from the real dataset parses to the size the CMS reports", () => {
+	// Taken from `*[_type == "sanity.imageAsset"]`, where metadata.dimensions
+	// says 1920x1245 for this asset. The id is the only copy of that the
+	// projections hand the renderer.
+	expect(
+		imageDimensions("image-012e0e333bd58453de1b25c266a5701b0ed1ce2d-1920x1245-jpg"),
+	).toStrictEqual({ width: 1920, height: 1245 });
+	expect(
+		imageDimensions("image-032a99868b85bdc3243216f4de2ca9791da8d627-800x800-png"),
+	).toStrictEqual({ width: 800, height: 800 });
+});
+
+test("an asset id containing digits and dashes does not confuse the parse", () => {
+	// The id is a hex hash; matching the *last* `<w>x<h>-<ext>` rather than the
+	// third dash-separated field is what keeps a stray `-800x600-` inside an id
+	// from winning.
+	expect(imageDimensions("image-1a2b3c4d5e6f7a8b9c0d-1920x1080-png")).toStrictEqual({
+		width: 1920,
+		height: 1080,
+	});
+});
+
+test("anything that is not an image reference has no dimensions", () => {
+	expect(imageDimensions("file-abc-pdf")).toBe(null);
+	expect(imageDimensions("image-abc-jpg")).toBe(null);
+	expect(imageDimensions("image-abc-1200x-jpg")).toBe(null);
+	expect(imageDimensions("not a reference at all")).toBe(null);
+});
+
+test("a missing reference is not an error", () => {
+	// The studio lets an editor insert an image block and leave it empty.
+	expect(imageDimensions(undefined)).toBe(null);
+	expect(imageDimensions(null)).toBe(null);
+	expect(imageDimensions("")).toBe(null);
+});
+
+test("a zero dimension is refused rather than passed to next/image", () => {
+	expect(imageDimensions("image-abc-0x0-jpg")).toBe(null);
+	expect(imageDimensions("image-abc-800x0-jpg")).toBe(null);
+});

--- a/libs/sanity-image.ts
+++ b/libs/sanity-image.ts
@@ -1,0 +1,23 @@
+import type { ImageDimensions } from "./types";
+
+// Sanity encodes an asset's pixel size in the reference itself:
+//
+//   image-<assetId>-<width>x<height>-<extension>
+//
+// next-sanity-image read them the same way, by splitting on `-` and taking the
+// third field. It is the only source of the intrinsic size: the GROQ
+// projections return a raw `asset._ref` and nothing else, and without a width
+// and height `next/image` cannot reserve the space, so a responsive layout
+// collapses to zero height and the article reflows as each image arrives.
+const DIMENSIONS = /-(\d+)x(\d+)-[a-z0-9]+$/i;
+
+/** The asset's intrinsic size, or null when the reference is not an image. */
+export const imageDimensions = (ref: string | null | undefined): ImageDimensions | null => {
+	const match = ref ? DIMENSIONS.exec(ref) : null;
+	if (!match) return null;
+
+	const width = Number(match[1]);
+	const height = Number(match[2]);
+
+	return width > 0 && height > 0 ? { width, height } : null;
+};

--- a/libs/types.ts
+++ b/libs/types.ts
@@ -25,6 +25,11 @@ export type PortableSpan = {
 	marks?: string[];
 };
 
+export type ImageDimensions = {
+	width: number;
+	height: number;
+};
+
 export type SanityImageRef = {
 	_ref: string;
 	_type: string;

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
   "dependencies": {
     "@heroicons/react": "1.0.6",
     "@portabletext/react": "1.0.6",
+    "@sanity/client": "3.4.1",
+    "@sanity/image-url": "1.0.1",
     "next": "12.3.1",
-    "next-sanity": "0.6.0",
-    "next-sanity-image": "4.1.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-icons": "4.4.0"

--- a/test/setup.tsx
+++ b/test/setup.tsx
@@ -65,8 +65,12 @@ vi.mock("next/router", () => ({
 }));
 
 // Imported at module scope by anything that touches the CMS, and it throws
-// without NEXT_PUBLIC_SANITY_ID. Nothing under test performs a fetch.
-vi.mock("../libs/clientApi", () => ({ default: { fetch: async () => null } }));
+// without NEXT_PUBLIC_SANITY_ID. Nothing under test performs a fetch, but the
+// image URL builder does read the config, so the stub carries one.
+vi.mock("../libs/clientApi", () => ({
+	default: { fetch: async () => null },
+	SANITY_PROJECT: { projectId: "test-project", dataset: "production" },
+}));
 
 beforeEach(() => {
 	setRouter();

--- a/yarn.lock
+++ b/yarn.lock
@@ -393,7 +393,7 @@
   resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz#e3fcee093fbb5ce765e1ad088ff4de2889f6f9be"
   integrity sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==
 
-"@sanity/client@^3.3.0":
+"@sanity/client@3.4.1":
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/@sanity/client/-/client-3.4.1.tgz#d1bd02bafc50eb0aac8d5b6fab942da52549652f"
   integrity sha512-WSvnroCHqboUeyY0nl71vDPKmfurXI0mtqdNDb5u8MW00CAHRyCt1+Sgy39D/g+6R35FYniV31vTSTo3ofim0A==
@@ -404,52 +404,15 @@
     object-assign "^4.1.1"
     rxjs "^6.0.0"
 
-"@sanity/client@^3.3.3":
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/@sanity/client/-/client-3.3.3.tgz#2eea3410b49365a1d5e05b4590eec4253ebe13a8"
-  integrity sha512-2n4S/d49abreTa1hLehtrQ9lLR8KhnXdIb7kZajkGPGh2yWwbtMXpB7e1dxNvySmFehrJx5rtwdeO3l2IhnHBA==
-  dependencies:
-    "@sanity/eventsource" "^4.0.0"
-    "@sanity/generate-help-url" "^3.0.0"
-    get-it "^6.1.1"
-    make-error "^1.3.0"
-    object-assign "^4.1.1"
-    rxjs "^6.0.0"
-
-"@sanity/color@^2.1.8":
-  version "2.1.13"
-  resolved "https://registry.yarnpkg.com/@sanity/color/-/color-2.1.13.tgz#c2d3115366e30ff64e7c26be5c591e7dfe150b32"
-  integrity sha512-V91q6GF16YQbTrOZLZ79ulWDq1cagdjysetycwu4HljrlJ5JVRrhIxppbmjIEiB5xvwTwI4kCTdCT3Fq8M+j3w==
-
 "@sanity/eventsource@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@sanity/eventsource/-/eventsource-4.0.0.tgz#ec9c352e87a2f79db8d25eedbb009ced21ec2e97"
-  integrity sha512-W0AD141JILOySJ177j2+HTr5k4tWNyXjGsr0dDXJzpqlwZ09J/uPHI73hMe5XtoFumPa9Bj6jy8uu2qdZX84NQ==
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@sanity/eventsource/-/eventsource-4.1.1.tgz#9a86c5d3dba4c8579cef813bf8bc63e05134413e"
+  integrity sha512-4RpexVqD+hbIXDgFLgWq/vSJWHNEBbc9eGa96ear/3ADFhMQx+QG4Q7r3QmQkB2t7LfUrrJfMQn9sMwaBTlurg==
   dependencies:
-    event-source-polyfill "1.0.25"
-    eventsource "^2.0.2"
+    event-source-polyfill "1.0.31"
+    eventsource "2.0.2"
 
-"@sanity/generate-help-url@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@sanity/generate-help-url/-/generate-help-url-3.0.0.tgz#60e9cba61b82103ea3761730a53cd9310b98892d"
-  integrity sha512-wtMYcV5GIDIhVyF/jjmdwq1GdlK07dRL40XMns73VbrFI7FteRltxv48bhYVZPcLkRXb0SHjpDS/icj9/yzbVA==
-
-"@sanity/groq-store@^0.4.0":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@sanity/groq-store/-/groq-store-0.4.1.tgz#2a1f834b2f53e75f2b1b2d8c8457f345b9d38ecf"
-  integrity sha512-duLH/moE5TxJkUfwDiCCeHzRfltV/vzT4Qle48CdaWqT90CMJ+6m31PC4J3FG1uzNWFc82rOP6SG5nfww9ea4Q==
-  dependencies:
-    "@sanity/types" "^2.0.1"
-    eventsource "^1.0.7"
-    fast-deep-equal "^3.1.3"
-    groq "^2.0.9"
-    groq-js "^1.0.1"
-    mendoza "^2.1.1"
-    simple-get "^4.0.1"
-    split2 "^4.1.0"
-    throttle-debounce "^5.0.0"
-
-"@sanity/image-url@^1.0.0":
+"@sanity/image-url@1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@sanity/image-url/-/image-url-1.0.1.tgz#960d649b2f4396da0adb31cf94503c929495cea0"
   integrity sha512-AdKQ3zMk7WdoNwoJPrAvQhW+kUtBldBX0nHtnGy+rwmgsCQ0rAXasrgH43Fhmsp/yB6piiq+F2d5qEuBFsdQVg==
@@ -458,16 +421,6 @@
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@sanity/timed-out/-/timed-out-4.0.2.tgz#c9f61f9a1609baa1eb3e4235a24ea2a775022cdf"
   integrity sha512-NBDKGj14g9Z+bopIvZcQKWCzJq5JSrdmzRR1CS+iyA3Gm8SnIWBfZa7I3mTg2X6Nu8LQXG0EPKXdOGozLS4i3w==
-
-"@sanity/types@^2.0.1":
-  version "2.30.5"
-  resolved "https://registry.yarnpkg.com/@sanity/types/-/types-2.30.5.tgz#53307b7f1d0786d7be14f5d772eabb0c0cdcd44c"
-  integrity sha512-5W6ndj9V9OeXWRwjmIAAPNNfC2fJQtwKjopXzFexFLSSJ84WyxTAzhShS7082NrHg4TaVZe3hVifPKFInERZ7Q==
-  dependencies:
-    "@sanity/client" "^3.3.3"
-    "@sanity/color" "^2.1.8"
-    "@types/react" "^17.0.42"
-    rxjs "^6.5.3"
 
 "@standard-schema/spec@^1.1.0":
   version "1.1.0"
@@ -561,20 +514,6 @@
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.2.2"
-
-"@types/react@^17.0.42":
-  version "17.0.48"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.48.tgz#a4532a8b91d7b27b8768b6fc0c3bccb760d15a6c"
-  integrity sha512-zJ6IYlJ8cYYxiJfUaZOQee4lh99mFihBoqkOSEGV+dFi9leROW6+PgstzQ+w3gWTnUfskALtQPGHK6dYmPj+2A==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/scheduler@*":
-  version "0.16.2"
-  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
-  integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
 "@typescript-eslint/parser@5.62.0":
   version "5.62.0"
@@ -802,9 +741,9 @@ caniuse-lite@^1.0.30001406:
   integrity sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==
 
 capture-stack-trace@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz#a6c0bbe1f38f3aa0b92238ecb6ff42c344d4135d"
-  integrity sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/capture-stack-trace/-/capture-stack-trace-1.0.2.tgz#1c43f6b059d4249e7f3f8724f15f048b927d3a8a"
+  integrity sha512-X/WM2UQs6VMHUtjUDnZTRI+i1crWteJySFzr9UpGoQa4WQffXVTTXuekjl7TjZRlcF2XfjgITT0HxZ9RnxeT0w==
 
 chai@^6.2.2:
   version "6.2.2"
@@ -889,11 +828,6 @@ css.escape@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
   integrity sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==
-
-csstype@^3.0.2:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.0.tgz#4ddcac3718d787cf9df0d1b7d15033925c8f29f2"
-  integrity sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==
 
 csstype@^3.2.2:
   version "3.2.3"
@@ -1105,17 +1039,12 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-event-source-polyfill@1.0.25:
-  version "1.0.25"
-  resolved "https://registry.yarnpkg.com/event-source-polyfill/-/event-source-polyfill-1.0.25.tgz#d8bb7f99cb6f8119c2baf086d9f6ee0514b6d9c8"
-  integrity sha512-hQxu6sN1Eq4JjoI7ITdQeGGUN193A2ra83qC0Ltm9I2UJVAten3OFVN6k5RX4YWeCS0BoC8xg/5czOCIHVosQg==
+event-source-polyfill@1.0.31:
+  version "1.0.31"
+  resolved "https://registry.yarnpkg.com/event-source-polyfill/-/event-source-polyfill-1.0.31.tgz#45fb0a6fc1375b2ba597361ba4287ffec5bf2e0c"
+  integrity sha512-4IJSItgS/41IxN5UVAVuAyczwZF7ZIEsM1XAoUzIHA6A+xzusEZUutdXz2Nr+MQPLxfTiCvqE79/C8HT8fKFvA==
 
-eventsource@^1.0.7:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-1.1.2.tgz#bc75ae1c60209e7cb1541231980460343eaea7c2"
-  integrity sha512-xAH3zWhgO2/3KIniEKYPr8plNSzlGINOUqYj0m0u7AB81iRw8b/3E73W6AuU+6klLbaSFmZnaETQ2lXPfAydrA==
-
-eventsource@^2.0.2:
+eventsource@2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-2.0.2.tgz#76dfcc02930fb2ff339520b6d290da573a9e8508"
   integrity sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==
@@ -1199,9 +1128,9 @@ flatted@^3.1.0:
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
 follow-redirects@^1.2.4:
-  version "1.15.1"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz#0ca6a452306c9b276e4d3127483e29575e207ad5"
-  integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
+  integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
 
 form-urlencoded@^2.0.7:
   version "2.0.9"
@@ -1321,16 +1250,6 @@ grapheme-splitter@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz#9cf3a665c6247479896834af35cf1dbb4400767e"
   integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
-
-groq-js@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/groq-js/-/groq-js-1.0.1.tgz#2641e9169fd4641b8ddad6f21b32baa1052a37d6"
-  integrity sha512-bv2UkWYkaQkZAEbsfKy+bqdeFAzrQnWZ7zYislCGANzhZSqBVf0uRKeY8r/nXdBiMwuMDA6TxHgwG2FJVKAy6Q==
-
-groq@^2.0.9, groq@^2.29.3:
-  version "2.29.3"
-  resolved "https://registry.yarnpkg.com/groq/-/groq-2.29.3.tgz#e767152202ab6aad64b2c33dfc904ee4e4c16d8e"
-  integrity sha512-j3HFq8Qwg36rREp2Xl2vecUz47LX6cedD8cqq+JKX0iNj9yiwelOSKpRS5jxhkDZQv5xBAiqtpU2Ylv5DQ5g2A==
 
 has-flag@^4.0.0:
   version "4.0.0"
@@ -1631,11 +1550,6 @@ mdn-data@2.27.1:
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.27.1.tgz#e37b9c50880b75366c4d40ac63d9bbcacdb61f0e"
   integrity sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==
 
-mendoza@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/mendoza/-/mendoza-2.1.1.tgz#19ad4efc3f424439d895e1f1841818a4e268af55"
-  integrity sha512-8f3Se8HDfobXCsdESXZBSSYcVzIRi+cMIEmz/SR4bjgFEjHJaXzrsBYr+vyrFGEtK5xTpCcU+DiwxWJV6hCuhQ==
-
 merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
@@ -1701,22 +1615,6 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-next-sanity-image@4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/next-sanity-image/-/next-sanity-image-4.1.0.tgz#4558db1d8b45f5891be0cdbb66476b1ae1dfa74b"
-  integrity sha512-DOKqiVJjGQb/FGPA5e5ezVK326w1GFx28J0XFt8XMtaaWzRfYdPQlkUhJdTDIAPIMMwQQwAmSxxA0r2rQpKigg==
-  dependencies:
-    "@sanity/image-url" "^1.0.0"
-
-next-sanity@0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/next-sanity/-/next-sanity-0.6.0.tgz#4c1c7017476412fc915d10f8b1ab740583ea33fd"
-  integrity sha512-Pcn5OnVWjKtjrecTXOvf2mZNdznmAcexbJrsEQmlAob877xey71iK09vdF5hhJzDPvRLqfXRG8nbJkwWmuPpzA==
-  dependencies:
-    "@sanity/client" "^3.3.0"
-    "@sanity/groq-store" "^0.4.0"
-    groq "^2.29.3"
-
 next@12.3.1:
   version "12.3.1"
   resolved "https://registry.yarnpkg.com/next/-/next-12.3.1.tgz#127b825ad2207faf869b33393ec8c75fe61e50f1"
@@ -1758,7 +1656,7 @@ obug@^2.1.1:
   resolved "https://registry.yarnpkg.com/obug/-/obug-2.1.4.tgz#9090d8a548a522517915d2aa6aae907197ac6cf8"
   integrity sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==
 
-once@^1.3.0, once@^1.3.1:
+once@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
@@ -1804,9 +1702,9 @@ parent-module@^1.0.0:
     callsites "^3.0.0"
 
 parse-headers@^2.0.4:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/parse-headers/-/parse-headers-2.0.5.tgz#069793f9356a54008571eb7f9761153e6c770da9"
-  integrity sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA==
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/parse-headers/-/parse-headers-2.0.6.tgz#7940f0abe5fe65df2dd25d4ce8800cb35b49d01c"
+  integrity sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A==
 
 parse5@^8.0.1:
   version "8.0.1"
@@ -1951,9 +1849,9 @@ react@18.2.0:
     loose-envify "^1.1.0"
 
 readable-stream@^2.0.0, readable-stream@~2.3.6:
-  version "2.3.7"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
-  integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.8.tgz#91125e8042bba1b9887f49345f6277027ce8be9b"
+  integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.3"
@@ -2041,7 +1939,7 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-rxjs@^6.0.0, rxjs@^6.5.3:
+rxjs@^6.0.0:
   version "6.6.7"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
   integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
@@ -2108,19 +2006,10 @@ siginfo@^2.0.0:
   resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
   integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
 
-simple-concat@^1.0.0, simple-concat@^1.0.1:
+simple-concat@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.1.tgz#f46976082ba35c2263f1c8ab5edfe26c41c9552f"
   integrity sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==
-
-simple-get@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-4.0.1.tgz#4a39db549287c979d352112fa03fd99fd6bc3543"
-  integrity sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==
-  dependencies:
-    decompress-response "^6.0.0"
-    once "^1.3.1"
-    simple-concat "^1.0.0"
 
 slash@^3.0.0:
   version "3.0.0"
@@ -2141,11 +2030,6 @@ speedometer@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/speedometer/-/speedometer-1.0.0.tgz#cd671cb06752c22bca3370e2f334440be4fc62e2"
   integrity sha512-lgxErLl/7A5+vgIIXsh9MbeukOaCb2axgQ+bKCdIE+ibNT4XNYGNCR1qFEGq6F+YDASXK3Fh/c5FgtZchFolxw==
-
-split2@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/split2/-/split2-4.1.0.tgz#101907a24370f85bb782f08adaabe4e281ecf809"
-  integrity sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==
 
 stackback@0.0.2:
   version "0.0.2"
@@ -2204,11 +2088,6 @@ text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
-
-throttle-debounce@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-5.0.0.tgz#a17a4039e82a2ed38a5e7268e4132d6960d41933"
-  integrity sha512-2iQTSgkkc1Zyk0MeVrt/3BvuOXYPl/R8Z0U2xxo9rjwNciaHDG3R+Lm6dh4EeUci49DanvBnuqI6jshoQQRGEg==
 
 through2@~2.0.3:
   version "2.0.5"


### PR DESCRIPTION
Step 2 of the Next 16 plan, and the small one. Two dependencies stood between this repo and Next 16, and each existed to re-export a single function.

## Motivation

```
next-sanity@13        peer: next ^16, react ^19.2.3, styled-components ^6.1
next-sanity-image@6   peer: next ^13 || ^14 || ^15        ← the hard cap
```

`next-sanity` supplied `createClient`. `next-sanity-image` supplied `useNextSanityImage`. Between them they declared a version range this repo cannot satisfy in either direction.

Neither underlying library carries a `next` or `react` peer at all:

```
@sanity/client@3.4.1     peers: none
@sanity/image-url@1.0.1  peers: none
```

So importing them directly removes the cap without touching a single version number. The client and image-url bumps belong with the upgrade, where they can be tested against Next 16 together.

## Solution

### The client

`libs/clientApi.ts` builds from `@sanity/client`. On the pinned version the constructor is the **default** export, not `createClient`, which only arrives in v4; that rename is upgrade work, not this PR's.

It also exports `SANITY_PROJECT`, and the image URL builder takes that plain `{ projectId, dataset }` rather than reaching into the client for its private `clientConfig`. That coupling is precisely what forced a new major of `@sanity/image-url`, and it is what would break on the next client bump. Decoupling it now means the upgrade does not have to touch the image path at all.

An absent `NEXT_PUBLIC_SANITY_ID` still produces ``Configuration must contain `projectId` ``, the error the local-development notes tell you to expect.

### The image component

`components/ui/sanityImage.tsx` reproduces what `useNextSanityImage` did by default, so the CDN keeps serving the same bytes for the same request: `auto=format`, `fit=clip`, quality 75, a loader that resizes on Sanity's CDN rather than through `/_next/image`, and a 64px blur-up placeholder at quality 30 with blur 50. I read that off the compiled `next-sanity-image` source rather than inferring it.

The intrinsic size moves into `libs/sanity-image.ts`, which is pure and therefore tested. Sanity encodes it in the asset reference itself (`image-<id>-<w>x<h>-<ext>`) and the GROQ projections return nothing else, so that reference is the only source. Without it `next/image` cannot reserve the space and a responsive layout collapses to zero height.

### An accessibility fix that came with it

The image now has an `alt` attribute. It sits on the Portable Text block rather than on the asset, so `rich-text.tsx` passes it through, falling back to `""`. The component previously omitted the attribute **entirely**, which is the one case worse than marking an image decorative: a screen reader falls back to announcing the URL. The `biome-ignore` for `useAltText` is gone with it.

## Verification

The tricky part: **no published document currently embeds a CMS image**, so this path is unexercised in production and cannot be checked by curling the site. Three angles instead:

1. **The parser**, in the fast node project. Fixtures include two real asset ids pulled from `*[_type == "sanity.imageAsset"]`, whose `metadata.dimensions` confirm the parse (`…-1920x1245-jpg` → 1920×1245). Plus the refusals: a non-image reference, a truncated one, a zero dimension, a missing one.
2. **The component**, in the jsdom project: that the size and the alt reach the DOM, that a studio-blank alt becomes `alt=""`, and that a block with no asset renders nothing.
3. **The live CDN**, by fetching all three URL shapes the component builds:

```
200  image/webp  268628 bytes   ?q=75&fit=clip&auto=format
200  image/webp   54504 bytes   ?w=800&q=75&fit=clip&auto=format      (loader)
200  image/webp     130 bytes   ?w=64&blur=50&q=30&fit=clip&auto=format
```

`auto=format` negotiating webp, the loader resizing, and the blur placeholder at 130 bytes all behave as before.

```
yarn verify   ✔ biome:check (0 errors, 11 advisory warnings)
              ✔ next lint
              ✔ tsc --noEmit
              ✔ 19 files, 154 tests   (was 18 / 145)
yarn build    ✔ 56 static pages
```

Plus the usual curl sweep against an isolated verification build: 14 routes 200 across both locales and every `.md` sibling, 406 / 405 / 308 / 404 on the negotiation branches.

## Notes

Dependencies are down to eight. Biome's `noFocusedTests` fires on the builder's `fit()` call, mistaking it for Jasmine's focused test, and carries a one-line suppression.

## Next

Step 3, the upgrade proper: 23 `<Link>` unwraps (codemod), 8 `next/image` `layout=` migrations, `images.domains` → `remotePatterns`, `next lint` removed in favour of the ESLint CLI, and `middleware` → `proxy`. The suite from #23 and this PR is the net it lands in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)