### PR TITLE
fix: open a markdown decorator once across the spans that share it

### DIFF
--- a/libs/portable-text-to-markdown.test.ts
+++ b/libs/portable-text-to-markdown.test.ts
@@ -106,3 +106,80 @@ test("images render as their alt text only", () => {
 	expect(toMarkdown([{ _type: "image", _key: "i" }])).toBe("");
 	expect(toMarkdown([{ _type: "image", _key: "i" }]).includes("![")).toBe(false);
 });
+
+const spans = (
+	parts: [string, string[]][],
+	markDefs: PortableNode["markDefs"] = [],
+): PortableNode => ({
+	_type: "block",
+	_key: "runs",
+	style: "normal",
+	markDefs,
+	children: parts.map(([text, marks], i) => ({
+		_type: "span",
+		_key: `s${i}`,
+		text,
+		marks,
+	})),
+});
+
+test("a decorator shared by consecutive spans is opened once", () => {
+	// What the guide stores for a bold sentence with one italic word in it.
+	// Wrapping each span on its own emitted `**a****_b_****c**`, where two `**`
+	// runs meet and CommonMark stops reading it as one bold sentence.
+	const value = [
+		spans([
+			["informé « ", ["strong"]],
+			["par tous moyens", ["em", "strong"]],
+			[" ».", ["strong"]],
+		]),
+	];
+	expect(toMarkdown(value)).toBe("**informé « _par tous moyens_ ».**");
+});
+
+test("mark order within a span does not change the nesting", () => {
+	const a = toMarkdown([spans([["x", ["em", "strong"]]])]);
+	const b = toMarkdown([spans([["x", ["strong", "em"]]])]);
+	expect(a).toBe(b);
+	expect(a).toBe("**_x_**");
+});
+
+test("consecutive spans sharing one link stay a single link", () => {
+	const value = [
+		spans(
+			[
+				["Guide", ["l1"]],
+				[" de survie", ["strong", "l1"]],
+			],
+			[{ _key: "l1", _type: "link", href: "https://example.test/a" }],
+		),
+	];
+	expect(toMarkdown(value)).toBe("[Guide** de survie**](https://example.test/a)");
+});
+
+test("adjacent links to different places stay separate", () => {
+	const value = [
+		spans(
+			[
+				["one", ["l1"]],
+				["two", ["l2"]],
+			],
+			[
+				{ _key: "l1", _type: "link", href: "https://example.test/a" },
+				{ _key: "l2", _type: "link", href: "https://example.test/b" },
+			],
+		),
+	];
+	expect(toMarkdown(value)).toBe("[one](https://example.test/a)[two](https://example.test/b)");
+});
+
+test("an unmarked span between two bold ones closes and reopens", () => {
+	const value = [
+		spans([
+			["a", ["strong"]],
+			[" and ", []],
+			["b", ["strong"]],
+		]),
+	];
+	expect(toMarkdown(value)).toBe("**a** and **b**");
+});

--- a/libs/portable-text-to-markdown.ts
+++ b/libs/portable-text-to-markdown.ts
@@ -19,29 +19,86 @@ const DECORATORS: Record<string, string> = {
 	code: "`",
 };
 
-const spanToMarkdown = (span: PortableSpan, markDefs: PortableMarkDef[]): string => {
-	const text = span.text ?? "";
-	if (!text) return "";
+// Marks are nested outermost first, in one fixed order, so that two spans
+// carrying the same set always produce the same nesting and can be recognised
+// as a single run. Sanity stores the set unordered: the guide has spans marked
+// ["em","strong"] sitting between spans marked ["strong"].
+const NESTING = ["strong", "em", "code"] as const;
 
+type Layer = { key: string; open: string; close: string };
+
+// A link is the outermost layer and is keyed by its href, so two consecutive
+// spans pointing at the same place stay one link rather than becoming two.
+const layersOf = (span: PortableSpan, markDefs: PortableMarkDef[]): Layer[] => {
 	const marks = span.marks ?? [];
-
-	const wrapped = marks.reduce((acc, mark) => {
-		const decorator = DECORATORS[mark];
-		return decorator ? `${decorator}${acc}${decorator}` : acc;
-	}, text);
+	const layers: Layer[] = [];
 
 	const link = marks
 		.map((mark) => markDefs.find((def) => def._key === mark))
 		.find((def) => def?._type === "link" && def.href);
 
-	return link ? `[${wrapped}](${link.href})` : wrapped;
+	if (link?.href) layers.push({ key: `link:${link.href}`, open: "[", close: `](${link.href})` });
+
+	for (const name of NESTING) {
+		const decorator = DECORATORS[name];
+		if (decorator && marks.includes(name))
+			layers.push({ key: name, open: decorator, close: decorator });
+	}
+
+	return layers;
 };
 
-const blockText = (block: PortableNode): string =>
-	(block.children ?? [])
-		.filter((child) => child._type === "span")
-		.map((span) => spanToMarkdown(span, block.markDefs ?? []))
+// How many layers the two runs already have in common, from the outside in.
+// Those stay open across the boundary; everything deeper is closed and the
+// new span's own layers opened after it.
+const sharedDepth = (open: Layer[], want: Layer[]): number => {
+	const limit = Math.min(open.length, want.length);
+	let shared = 0;
+	while (shared < limit && open[shared]?.key === want[shared]?.key) shared++;
+	return shared;
+};
+
+const closeFrom = (open: Layer[], depth: number): string =>
+	open
+		.slice(depth)
+		.reverse()
+		.map((layer) => layer.close)
 		.join("");
+
+const openFrom = (want: Layer[], depth: number): string =>
+	want
+		.slice(depth)
+		.map((layer) => layer.open)
+		.join("");
+
+// Emphasis is opened and closed across the run of spans that share it, rather
+// than around each span.
+//
+// Closing and reopening at every span boundary is what produced `****` in the
+// markdown of the garde à vue guide: a bold sentence with one italic word
+// inside it is stored as three spans, ["strong"], ["em","strong"], ["strong"],
+// and wrapping each on its own emitted `**a****_b_****c**`. Two `**` runs meet,
+// and CommonMark does not read that as the bold sentence it came from.
+const blockText = (block: PortableNode): string => {
+	const markDefs = block.markDefs ?? [];
+	const spans = (block.children ?? []).filter((child) => child._type === "span");
+
+	let out = "";
+	let open: Layer[] = [];
+
+	for (const span of spans) {
+		const text = span.text ?? "";
+		if (!text) continue;
+
+		const want = layersOf(span, markDefs);
+		const shared = sharedDepth(open, want);
+
+		out += closeFrom(open, shared) + openFrom(want, shared) + text;
+		open = want;
+	}
+
+	return out + closeFrom(open, 0);
+};
 
 // Sanity stores an empty paragraph where the editor wanted air. Markdown gets
 // that from the blank line between blocks, so the spacer is dropped.


### PR DESCRIPTION
## The bug

The markdown representation of the garde à vue guide was corrupt in ten published blocks. An agent asking any of those pages for `text/markdown` received this:

```
L'avocat, commis d'office ou choisi, doit être** informé « ****_par tous
moyens et sans délai_**** ».**
```

A bold sentence containing one italic word is stored by Sanity as three spans:

```
["strong"]        "informé « "
["em","strong"]   "par tous moyens et sans délai"
["strong"]        " »."
```

`spanToMarkdown` wrapped each span on its own, so the three became `**a****_b_****c**`. Two `**` runs meet, and CommonMark does not read that as the bold sentence it came from.

Twenty blocks across the dataset serialised that way, ten of them published. **None** were in the forty-five drafts from #21, which is why it only surfaced while auditing the old guide rather than while writing new material.

The Portable Text is well formed. The bug was entirely in `libs/portable-text-to-markdown.ts`.

## How it was found

Not by reading the code. While auditing the published guide for formatting problems I diffed what the live `text/markdown` endpoint actually returns against what the CMS holds, and the `****` fell out of that. Two other findings from the same audit were content rather than code and are already applied and published in Sanity:

- 445 empty Portable Text blocks removed across the ten published posts: `<br>` spacers, empty list items that were fragmenting one list into several `<ul>` and reaching agents as bare `- ` lines, and one empty `h4`
- 60 `strong` marks removed from headings, 25 spans trimmed of edge whitespace, explicit slugs set on all ten so a future title edit cannot silently move a URL

Only the serialiser needed a code change, and that is this PR.

## Solution

Emphasis is opened when it starts applying and closed when it stops, across the whole run of spans that share it, rather than around each span.

- Marks nest in one fixed order (`strong`, `em`, `code`), so a span marked `["em","strong"]` and one marked `["strong","em"]` are recognised as the same run. Sanity stores the set unordered.
- A link is the outermost layer and is keyed by its href, so consecutive spans pointing at the same place stay one link instead of becoming two.
- `sharedDepth` / `closeFrom` / `openFrom` are split out because the first version tripped Biome's cognitive-complexity ceiling at 17 against a max of 15.

Five tests: the shared decorator, mark-order independence, merged links, adjacent links to different places, and an unmarked span between two bold ones.

## Checks

`yarn verify` passes on current `main` (Next 16, React 19): Biome clean, ESLint clean, `tsc --noEmit` clean, **Vitest 159 across 19 files**.

Beyond the unit tests, the new serialiser was run over every block in the dataset, published and draft, 58 documents:

- **zero** blocks left with colliding delimiters
- stripping the delimiters returns the span text unchanged, so no text moved

That second check initially failed twice, both times because the *check* was wrong rather than the serialiser: an underscore-stripping regex that mangled `_any observations_`, and a list-marker strip that ate a leading `"- "` from a paragraph that legitimately begins with one. Worth knowing that paragraph exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)