### PR TITLE
fix: give publications their own measure, filled to the column and capped

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -421,7 +421,20 @@ axis and `font-optical-sizing: auto` so the sizes it *is* used at stay solid.
 labels, buttons and the colophon all use it.
 
 Headings are **uppercase** with slightly negative tracking. Body copy is
-`$ink-muted`, capped at `$measure` (62ch).
+`$ink-muted`, capped at `$measure` (39rem, 624px, about 84 characters a line at
+the 1rem body size).
+
+`$measure` was `62ch` and is a fixed length now. `ch` is the width of the `0`
+glyph, and Inter's `0` is a third wider than its average letter, so `62ch` never
+meant 62 characters, it meant about 84. Worse, it scaled with the font size of
+whatever it was applied to: on the ISKA tagline, at 40px, the same token was
+1378px. A length means one thing everywhere, and the characters per line follow
+from the font size of the text inside it.
+
+`$measure-wide` (60rem) is the second measure, for a publication with no episode
+index beside it. Both are anchored left, where the banner and the meta rule
+start; a centred column reads as floating on a page whose every other edge is
+flush left.
 
 ### Scale
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -431,10 +431,17 @@ whatever it was applied to: on the ISKA tagline, at 40px, the same token was
 1378px. A length means one thing everywhere, and the characters per line follow
 from the font size of the text inside it.
 
-`$measure-wide` (60rem) is the second measure, for a publication with no episode
-index beside it. Both are anchored left, where the banner and the meta rule
-start; a centred column reads as floating on a page whose every other edge is
-flush left.
+`$measure-wide` (60rem) is the publications measure, and it is a **cap, not a
+width**. `.body` fills whatever grid column it is given and stops at the cap.
+Beside the episode index that column is narrower and wins, so a guide episode
+sets at 832px on a 1440px screen with its right edge flush against the meta rule
+and the banner, and it stays flush at every width because it is the column
+rather than a number. An article has no index, so its row is the whole container
+and the cap is what stops it; without one it ran to 164 characters a line.
+
+Both are anchored left, where the banner and the meta rule start. A centred
+column reads as floating on a page whose every other edge is flush left.
+`$measure` is the blurb width and is not used by publications.
 
 ### Scale
 

--- a/components/layout/publication-page.module.scss
+++ b/components/layout/publication-page.module.scss
@@ -93,20 +93,11 @@
   min-width: 0;
 
   // An article outside a guide has no index beside it, so it takes the row
-  // rather than the 17rem column auto-placement would drop it into. Only the
-  // row: dropping the measure with it ran the prose across the full 1200px
-  // container at 164 characters a line.
-  //
-  // It takes $measure-wide and stays hard left, where the banner and the meta
-  // rule already start. Centred in the row it read as a block floating in the
-  // middle of the page; against the left edge it is the same column the guide
-  // has beside its index, and the air falls on the right of both.
+  // rather than the 17rem column auto-placement would drop it into. The prose
+  // needs no rule of its own here: .body is capped at $measure-wide and fills
+  // whatever column it is given, which is this whole row.
   &:only-child {
     grid-column: 1 / -1;
-
-    .body {
-      max-width: $measure-wide;
-    }
   }
 }
 
@@ -137,7 +128,15 @@
 }
 
 .body {
-  max-width: $measure;
+  // Fill the column, up to a cap. Beside the index that column is 832px and
+  // the prose ends flush with the meta rule and the banner above it, which is
+  // where the eye already expects the page to stop; on an article, which has
+  // no index, the row is the full container and the cap is what stops it
+  // running to 164 characters a line.
+  //
+  // Not $measure: that is the blurb width, right for the three paragraphs on
+  // /about and short for a thousand words here.
+  max-width: $measure-wide;
   margin-top: $space-5;
 
   // One heading treatment for every level. A piece of this length wants a

--- a/components/layout/publication-page.module.scss
+++ b/components/layout/publication-page.module.scss
@@ -93,13 +93,19 @@
   min-width: 0;
 
   // An article outside a guide has no index beside it, so it takes the row
-  // rather than the 17rem column auto-placement would drop it into, and its
-  // text runs the full container instead of stopping at the measure.
+  // rather than the 17rem column auto-placement would drop it into. Only the
+  // row: dropping the measure with it ran the prose across the full 1200px
+  // container at 164 characters a line.
+  //
+  // It takes $measure-wide and stays hard left, where the banner and the meta
+  // rule already start. Centred in the row it read as a block floating in the
+  // middle of the page; against the left edge it is the same column the guide
+  // has beside its index, and the air falls on the right of both.
   &:only-child {
     grid-column: 1 / -1;
 
     .body {
-      max-width: none;
+      max-width: $measure-wide;
     }
   }
 }

--- a/styles/_variables.scss
+++ b/styles/_variables.scss
@@ -161,8 +161,11 @@ $lh-heading: 1.25;
 // is now set by the font size of the text inside it.
 $measure: 39rem;
 
-// A publication with no episode index beside it runs wider. It still needs a
-// bound: with none it took the whole 1200px container at 164 characters a
-// line, the widest text on the site by a distance.
+// The publications measure. Long-form runs wider than the blurbs $measure was
+// drawn for, and it is a cap rather than a width: beside the episode index the
+// grid column is narrower and wins, so a guide episode sets at 832px with its
+// right edge flush against the meta rule, and an article with no index sets at
+// this. Without any cap that article took the whole 1200px container, which is
+// 164 characters a line.
 $measure-wide: 60rem;
 $fs-micro: 0.75rem;

--- a/styles/_variables.scss
+++ b/styles/_variables.scss
@@ -151,5 +151,18 @@ $lh-display: 1.02;
 $lh-title: 1.1;
 $lh-heading: 1.25;
 
-$measure: 62ch;
+// The reading measure, as a fixed length rather than in `ch`.
+//
+// `ch` is the width of the `0` glyph and scales with the font size, which made
+// this token mean two different things at once: 62ch rendered as 625px and
+// about 84 characters a line, and raising the prose size would have widened the
+// column without shortening the line at all. 39rem is the same 624px it has
+// always been, so every surface using it is unchanged, and the character count
+// is now set by the font size of the text inside it.
+$measure: 39rem;
+
+// A publication with no episode index beside it runs wider. It still needs a
+// bound: with none it took the whole 1200px container at 164 characters a
+// line, the widest text on the site by a distance.
+$measure-wide: 60rem;
 $fs-micro: 0.75rem;


### PR DESCRIPTION
## Where this started

A question about whether `$measure: 62ch` was the right value for the guide articles. It was not, and the reason it was hard to see is worth writing down.

**`ch` is the width of the `0` glyph, not a character.** Inter's `0` is about a third wider than its average letter, so `62ch` never meant 62 characters. Measured on the live site it was 625px and **84 characters** a line. Worse, `ch` scales with the font size of whatever it is applied to, so a single token meant 625px on a paragraph and **1378px** on the ISKA tagline at 40px. It read like a measure and behaved like a container width.

That is why the token is now a fixed length. `39rem` is the 624px it has always rendered as; its four blurb surfaces (`expertise-fields`, `firm-section`, `iska` x2) are unchanged to the pixel.

## The actual defect

The two publication layouts disagreed by 2x, and neither number was chosen.

| | prose width | characters a line |
|---|---|---|
| Guide episode, index beside it | 625px | 84 |
| Article, no index | **1200px** | **164** |

An article outside a guide is placed with `grid-column: 1 / -1` so it takes the row rather than the 17rem index column. That was right. Dropping the measure at the same time was not:

```scss
&:only-child {
  grid-column: 1 / -1;
  .body { max-width: none; }   // <- ran the prose across the whole container
}
```

164 characters is the widest text on the site, and it lands on 20 of the 45 pieces from #21: S1 to S20 have no series, so no rail, so this path.

The guide had the opposite problem. Its column is 832px but the prose stopped at 625px, so every paragraph ended 207px short of the meta rule and the banner above it.

## How the shape was chosen

Recorded because several plausible answers were tried and rejected on the rendering, not in the abstract:

- **Raising the prose to 18px.** Rejected. `ch` scales with font size, so `62ch` is ~84 characters at *any* size: type size moves physical width, not line length. Two independent knobs, and this was the wrong one.
- **Narrowing the article to the guide's measure and centring it.** Rejected. Centred in the row it read as a block floating in the middle of a page whose every other edge is flush left.
- **Left-aligning instead of centring.** This was the turn. Anchored to the same edge as the banner and the meta rule, the column stops looking shrunken and starts looking deliberate.
- **A separate `$measure-wide` plus a `:only-child` override.** Superseded. Once the article is left-anchored, one cap on `.body` covers both layouts and the override deletes itself.

## Solution

`.body` takes one cap, `$measure-wide`, and fills whatever column it is given.

**The guide number is not chosen.** It is whatever is left after the 17rem index and the 6rem gap, so the prose ends flush against the meta rule and the banner, and it stays flush at every width rather than being a number that happens to look right at one.

`$measure` keeps its 39rem and its four blurb surfaces, and is no longer used by publications. Three paragraphs on `/about` and a thousand words of legal French do not want the same measure; one token pretending to serve both is what sent this hunting for a single number.

121 characters is longer than the ~75 a line is comfortable at. That is a deliberate call: these are meant to read wide.

## Verified against a real build

Measured on `next start` off this branch, on current `main`, in Chrome with scripts stripped so nothing rehydrates:

| | width | characters | prose right edge | rule right edge |
|---|---|---|---|---|
| Guide @1440 | 832px | 109 | 1320 | **1320** |
| Guide @1280 | 784px | 102 | 1216 | **1216** |
| Article @1440 | 960px | 121 | 1080 | 1320 |
| Article @1280 | 960px | 121 | 1024 | 1216 |

The flush edge holds at both widths.

The character counts moved from earlier estimates because **`next/font` self-hosts a different Inter cut** since #27: `1ch` is 9.52px, not 10.08px. The design is unaffected, because the guide fills its column by construction rather than by a number. It is a neat demonstration of the original problem: the font changed underneath, and a `ch`-based measure would have silently resized every surface with it.

Compiled the module with sass; exactly one rule sets a width under `.body` or `.article`:

```
".body" -> max-width: 60rem
```

`yarn verify` passes: Biome clean, ESLint clean, `tsc --noEmit` clean, Vitest 154.

## Notes

Two things seen while verifying, neither caused by this branch:

- On a clean local build `next start` serves publications at 200 but 404s `/`, `/about`, `/iska`, `/contact` and their `/fr` forms, though the build generates them. Vercel's preview is unaffected.
- A stale `.next` mixing webpack and Turbopack artefacts produces `Cannot find module '../webpack-runtime.js'`, and leaves a root `static/media/` that Next 16 then warns is deprecated. `rm -rf .next static` clears both; a clean Next 16 build does not recreate `static/`.

Press cuttings and the firm's own articles share one width. If 121 characters suits a 250 word cutting but not a 900 word article, the split is one condition on `isPress(post)`, which the codebase already computes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)