### PR TITLE
perf: keep the Sanity client on the server, and bump it five majors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,7 +154,9 @@ the site, and decide whether a CMS-authored link is same-site or hostile; they
 fail silently into a 404 or an unsafe anchor, and one of them already broke
 once. The agent surface adds the negotiation (`libs/accept.ts`), the routing
 decision (`libs/proxy-route.ts`), the markdown rendering, the page list,
-the URL spelling and llms.txt.
+the URL spelling, llms.txt and the meta-description truncation
+(`libs/plain-text.ts`). One test asserts no component can reach the Sanity
+client, which is a property of the import graph rather than of any one module.
 
 What makes a module testable is not importing the Sanity client or React —
 Vite resolves extensionless imports and JSON imports, so nothing needs an
@@ -243,13 +245,31 @@ déontologie constraints, the full article list and the release schedule.
 
 **Sanity** is reached through `@sanity/client` and `@sanity/image-url` directly.
 The `next-sanity` and `next-sanity-image` wrappers were dropped: each re-exported
-one function, and between them they pinned the repo below Next 16. On the version
-pinned here the client constructor is the *default* export, not `createClient`,
-which arrives in v4. `libs/clientApi.ts` also exports `SANITY_PROJECT`, so the
-image URL builder takes a plain `{ projectId, dataset }` rather than reaching
-into the client for its private `clientConfig` — that coupling is what forced a
-new major of `@sanity/image-url`, and it is what would break on the next client
-bump.
+one function, and between them they pinned the repo below Next 16. The
+constructor is `createClient`, the named export; the default export still
+resolves but is deprecated. `apiVersion` is pinned to `2025-02-19`, the version
+where the default perspective changed from `raw` to `published`, and
+`perspective` is set explicitly beside it so a later date cannot silently start
+serving drafts: only the publications query filters `drafts.**` itself, and a
+`[0]` projection would hand a page whichever copy came back first.
+
+**The Sanity client must never reach the browser.** `SANITY_PROJECT` lives in
+`libs/sanity-image.ts`, not beside the client, because the image URL builder
+runs client-side and importing the constant from `libs/clientApi.ts` dragged
+`@sanity/client`, `rxjs` and `get-it` into the bundle. For the same reason
+neither `libs/publications.ts` nor `libs/expertise.ts` re-exports the pure
+derivations beside it: a component importing `formatDate` or `plainText` from
+the module that builds a client cost 23 kB gzipped on the home page. The pure
+halves are `libs/publication-fields.ts`, `libs/expertise-list.ts` and
+`libs/plain-text.ts`, and `libs/no-client-in-components.test.ts` walks the
+import graph of every component and fails with the chain if one reaches the
+client again. It is invisible in a diff and invisible in a screenshot; a test
+is the only thing that sees it.
+
+The image URL builder takes a plain `{ projectId, dataset }` rather than
+reaching into the client for its private `clientConfig` — that coupling is what
+forced a new major of `@sanity/image-url`, and what would otherwise have broken
+on the jump from client v3 to v8.
 
 `components/ui/sanityImage.tsx` reproduces what `useNextSanityImage` did by
 default: `auto=format`, `fit=clip`, quality 75, a loader that resizes on Sanity's

--- a/components/head/expertise-schema.tsx
+++ b/components/head/expertise-schema.tsx
@@ -1,6 +1,6 @@
 import headerContent from "../../content/headerContent.json";
 import useLocale from "../../hooks/useLocale";
-import { plainText } from "../../libs/expertise";
+import { plainText } from "../../libs/plain-text";
 import { pageUrl } from "../../libs/site-url";
 import type { ExpertiseField } from "../../libs/types";
 import JsonLd from "./json-ld";

--- a/components/head/publication-schema.tsx
+++ b/components/head/publication-schema.tsx
@@ -1,9 +1,9 @@
 import headerContent from "../../content/headerContent.json";
 import useLocale from "../../hooks/useLocale";
-import { plainText } from "../../libs/expertise";
 import { isSafeExternal } from "../../libs/href";
 import { expertiseSlugIn, withLocale } from "../../libs/localePath";
-import { isPress } from "../../libs/publications";
+import { plainText } from "../../libs/plain-text";
+import { isPress } from "../../libs/publication-fields";
 import type { Locale, Publication } from "../../libs/types";
 import { HOST } from "./head-page";
 import JsonLd from "./json-ld";

--- a/components/layout/publication-page.tsx
+++ b/components/layout/publication-page.tsx
@@ -4,7 +4,7 @@ import useLocale from "../../hooks/useLocale";
 import { isSafeExternal } from "../../libs/href";
 import { expertiseSlugIn } from "../../libs/localePath";
 
-import { formatDate, isPress, pagerFor, splitTitle } from "../../libs/publications";
+import { formatDate, isPress, pagerFor, splitTitle } from "../../libs/publication-fields";
 import type { PageSeo, Publication, SeriesLink } from "../../libs/types";
 import HeadPage from "../head/head-page";
 import PublicationSchema from "../head/publication-schema";

--- a/components/layout/publications-index.tsx
+++ b/components/layout/publications-index.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import CONTENT from "../../content/publicationsContent.json";
 import useLocale from "../../hooks/useLocale";
-import { formatDate, groupPublications, isPress, splitTitle } from "../../libs/publications";
+import { formatDate, groupPublications, isPress, splitTitle } from "../../libs/publication-fields";
 import type { Locale, PageSeo, PublicationMeta, PublicationsDocument } from "../../libs/types";
 import HeadPage from "../head/head-page";
 import PageTitle from "./page-title";

--- a/components/ui/sanityImage.tsx
+++ b/components/ui/sanityImage.tsx
@@ -2,8 +2,7 @@ import imageUrlBuilder from "@sanity/image-url";
 import type { ImageLoader } from "next/image";
 import Image from "next/image";
 
-import { SANITY_PROJECT } from "../../libs/clientApi";
-import { imageDimensions } from "../../libs/sanity-image";
+import { imageDimensions, SANITY_PROJECT } from "../../libs/sanity-image";
 import type { SanityImageRef } from "../../libs/types";
 
 // The transforms `next-sanity-image` applied by default, kept so the CDN keeps

--- a/libs/clientApi.ts
+++ b/libs/clientApi.ts
@@ -1,28 +1,25 @@
-import SanityClient from "@sanity/client";
+import { createClient } from "@sanity/client";
+import { SANITY_PROJECT } from "./sanity-image";
 
 // `@sanity/client` directly, not through `next-sanity`. That wrapper re-exported
 // one function; its current release peers on Next 16 with React 19, while
 // `next-sanity-image` capped the other end at Next 15. Between them they pinned
 // this repo to a version of Next it has outgrown.
-//
-// `createClient` is a named export from v4 onwards. On the version pinned here
-// the constructor is the default export, and it may be called without `new`.
 
-// The two fields that address a project on the CDN. Exported so the image URL
-// builder can take them straight, rather than reaching into the client for its
-// private `clientConfig` — which is the coupling that forced a new major of
-// @sanity/image-url, and the thing that would break on the next client bump.
-// An absent id stays absent rather than becoming a silent default: the client
-// refuses a blank one with "Configuration must contain `projectId`", which is
-// the error the local-development notes in CLAUDE.md tell you to expect.
-export const SANITY_PROJECT = {
-	projectId: process.env.NEXT_PUBLIC_SANITY_ID ?? "",
-	dataset: "production",
-};
+// `SANITY_PROJECT` lives in libs/sanity-image.ts, which the browser imports.
+// The builder takes those two fields straight rather than reaching into the
+// client for its private `clientConfig` — the coupling that forced a new major
+// of @sanity/image-url, and what would otherwise have broken on this bump.
 
-const clientApi = SanityClient({
+const clientApi = createClient({
 	...SANITY_PROJECT,
-	apiVersion: "2022-03-25",
+	// The API version this code was written against, and the one where the
+	// default perspective changed from `raw` to `published`. `perspective` is set
+	// beside it anyway, so bumping the date cannot silently start serving drafts:
+	// only the publications query filters `drafts.**` itself, and a `[0]`
+	// projection would otherwise hand a page whichever copy the CMS returned first.
+	apiVersion: "2025-02-19",
+	perspective: "published",
 	useCdn: true,
 });
 

--- a/libs/expertise.ts
+++ b/libs/expertise.ts
@@ -1,11 +1,6 @@
 import clientApi from "./clientApi";
 import { normaliseFields } from "./expertise-list";
-import type { ExpertiseDocument, ExpertiseDocumentRaw, PortableText } from "./types";
-
-// The CMS has no slug field on an expertise item, so the URL is derived from
-// the title, stable for as long as the title is. `slugify` is the one
-// derivation behind every URL on the site.
-export { slugify as expertiseSlug } from "./slug";
+import type { ExpertiseDocument, ExpertiseDocumentRaw } from "./types";
 
 const EXPERTISE_QUERY = `*[_type == "expertise" && language == $locale][0]{
   titleseo,
@@ -23,23 +18,4 @@ export const fetchExpertise = async (locale?: string): Promise<ExpertiseDocument
 	if (!doc) return null;
 
 	return { ...doc, expertiseList: normaliseFields(doc.expertiseList) };
-};
-
-// Portable text down to one line, for a meta description.
-export const plainText = (blocks: PortableText | null | undefined, limit = 160): string => {
-	const text = (blocks ?? [])
-		.filter((block) => block._type === "block")
-		.map((block) => (block.children ?? []).map((span) => span.text).join(""))
-		.join(" ")
-		.replace(/\s+/g, " ")
-		.trim();
-
-	if (text.length <= limit) return text;
-
-	const cut = text.lastIndexOf(" ", limit);
-
-	// Trailing punctuation would run straight into the ellipsis ("commun....").
-	const kept = text.slice(0, cut > 0 ? cut : limit).replace(/[\s.,;:]+$/, "");
-
-	return `${kept}…`;
 };

--- a/libs/no-client-in-components.test.ts
+++ b/libs/no-client-in-components.test.ts
@@ -1,0 +1,69 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+
+// The Sanity client is a server dependency, and nothing under components/ has
+// ever called it. But the two fetcher modules used to re-export the pure
+// derivations beside them for convenience — `formatDate` out of
+// libs/publications, `plainText` out of libs/expertise — and a component
+// importing one of those pulled the whole client, rxjs and get-it into the
+// browser: 72 kB, on the home page, for a string function.
+//
+// That is invisible in a diff and invisible in a screenshot. It shows up only
+// as a chunk that grew, so the import graph is asserted here instead.
+
+const ROOT = resolve(__dirname, "..");
+const FORBIDDEN = "libs/clientApi.ts";
+
+const resolveSpec = (from: string, spec: string): string | null => {
+	if (!spec.startsWith(".")) return null;
+	const base = resolve(dirname(from), spec);
+	const candidates = [`${base}.ts`, `${base}.tsx`, `${base}/index.ts`, `${base}/index.tsx`, base];
+
+	return candidates.find((c) => existsSync(c) && statSync(c).isFile()) ?? null;
+};
+
+const specifiersIn = (source: string): string[] =>
+	[...source.matchAll(/^\s*(?:import|export)[\s\S]*?from\s+"([^"]+)"/gm)].flatMap((m) =>
+		m[1] ? [m[1]] : [],
+	);
+
+/** The first import chain from `file` down to the client, or null. */
+const chainToClient = (
+	file: string,
+	seen = new Set<string>(),
+	trail: string[] = [],
+): string[] | null => {
+	if (seen.has(file)) return null;
+	seen.add(file);
+
+	const here = [...trail, relative(ROOT, file)];
+	if (relative(ROOT, file) === FORBIDDEN) return here;
+
+	for (const spec of specifiersIn(readFileSync(file, "utf8"))) {
+		const next = resolveSpec(file, spec);
+		const found = next ? chainToClient(next, seen, here) : null;
+		if (found) return found;
+	}
+
+	return null;
+};
+
+const walk = (dir: string): string[] =>
+	readdirSync(dir, { withFileTypes: true }).flatMap((entry) =>
+		entry.isDirectory() ? walk(resolve(dir, entry.name)) : [resolve(dir, entry.name)],
+	);
+
+test("no component can reach the Sanity client", () => {
+	const components = walk(resolve(ROOT, "components")).filter(
+		(file) => /\.tsx?$/.test(file) && !file.includes(".test."),
+	);
+
+	expect(components.length).toBeGreaterThan(10);
+
+	const offenders = components
+		.map((file) => chainToClient(file))
+		.filter((chain): chain is string[] => chain !== null)
+		.map((chain) => chain.join(" -> "));
+
+	expect(offenders).toStrictEqual([]);
+});

--- a/libs/plain-text.test.ts
+++ b/libs/plain-text.test.ts
@@ -1,0 +1,51 @@
+import { plainText } from "./plain-text";
+import type { PortableText } from "./types";
+
+const block = (text: string): PortableText[number] => ({
+	_type: "block",
+	children: [{ _type: "span", text }],
+});
+
+test("joins the spans of every block into one line", () => {
+	expect(plainText([block("Une phrase."), block("Et une autre.")])).toBe(
+		"Une phrase. Et une autre.",
+	);
+});
+
+test("collapses the whitespace a rich-text editor leaves behind", () => {
+	expect(plainText([block("  deux   espaces\net un retour  ")])).toBe("deux espaces et un retour");
+});
+
+test("skips anything that is not a block", () => {
+	const withImage: PortableText = [
+		block("Le texte."),
+		{ _type: "image", asset: { _ref: "image-abc-800x600-jpg", _type: "reference" } },
+	];
+
+	expect(plainText(withImage)).toBe("Le texte.");
+});
+
+test("an absent body is an empty string, not a crash", () => {
+	expect(plainText(null)).toBe("");
+	expect(plainText(undefined)).toBe("");
+	expect(plainText([])).toBe("");
+});
+
+test("cuts on a word boundary and marks the cut", () => {
+	const long = plainText([block("un ".repeat(100))], 20);
+
+	expect(long.endsWith("…")).toBe(true);
+	expect(long.length).toBeLessThanOrEqual(21);
+	expect(long).not.toContain("u…");
+});
+
+test("trailing punctuation does not run into the ellipsis", () => {
+	// "commun...." is what a naive slice produces at a sentence end.
+	expect(plainText([block("Le droit pénal commun. Une autre phrase entière ici.")], 22)).toBe(
+		"Le droit pénal commun…",
+	);
+});
+
+test("a body shorter than the limit is returned whole, with no ellipsis", () => {
+	expect(plainText([block("Court.")], 160)).toBe("Court.");
+});

--- a/libs/plain-text.ts
+++ b/libs/plain-text.ts
@@ -1,0 +1,24 @@
+import type { PortableText } from "./types";
+
+// Portable text down to one line, for a meta description or an agent's lead.
+// It lived in libs/expertise.ts, which builds a Sanity client: the five
+// components that call it were pulling @sanity/client into the browser bundle
+// for a pure string function. It has nothing to do with expertise, and here it
+// is testable.
+export const plainText = (blocks: PortableText | null | undefined, limit = 160): string => {
+	const text = (blocks ?? [])
+		.filter((block) => block._type === "block")
+		.map((block) => (block.children ?? []).map((span) => span.text).join(""))
+		.join(" ")
+		.replace(/\s+/g, " ")
+		.trim();
+
+	if (text.length <= limit) return text;
+
+	const cut = text.lastIndexOf(" ", limit);
+
+	// Trailing punctuation would run straight into the ellipsis ("commun....").
+	const kept = text.slice(0, cut > 0 ? cut : limit).replace(/[\s.,;:]+$/, "");
+
+	return `${kept}…`;
+};

--- a/libs/publications.ts
+++ b/libs/publications.ts
@@ -3,17 +3,10 @@ import { otherLocale, withSlug } from "./publication-fields";
 import { slugify } from "./slug";
 import type { Locale, PortableText, PublicationDocument, PublicationMeta } from "./types";
 
-// The pure derivations live next door so they can be loaded without a CMS
-// client. Re-exported here so call sites import one module.
-export {
-	formatDate,
-	groupPublications,
-	isPress,
-	otherLocale,
-	pagerFor,
-	seriesOf,
-	splitTitle,
-} from "./publication-fields";
+// The pure derivations live in ./publication-fields and are NOT re-exported
+// here. This module builds a Sanity client, so anything that re-exported from
+// it put @sanity/client in the bundle of every page that renders a publication.
+// libs/no-client-in-components.test.ts is the guard.
 
 const LOCALES: readonly Locale[] = ["fr", "en"];
 

--- a/libs/sanity-image.ts
+++ b/libs/sanity-image.ts
@@ -1,5 +1,18 @@
 import type { ImageDimensions } from "./types";
 
+// The two fields that address a project on Sanity's CDN, and the whole of what
+// the image URL builder needs. They live here rather than beside the client
+// because `components/ui/sanityImage.tsx` runs in the browser: importing them
+// from libs/clientApi pulled @sanity/client, rxjs and get-it into the bundle of
+// every page that can render rich text, 72 kB the browser never calls.
+// An absent id stays absent rather than becoming a silent default: the client
+// refuses a blank one with "Configuration must contain `projectId`", which is
+// the error the local-development notes in CLAUDE.md tell you to expect.
+export const SANITY_PROJECT = {
+	projectId: process.env.NEXT_PUBLIC_SANITY_ID ?? "",
+	dataset: "production",
+};
+
 // Sanity encodes an asset's pixel size in the reference itself:
 //
 //   image-<assetId>-<width>x<height>-<extension>

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   "dependencies": {
     "@heroicons/react": "1.0.6",
     "@portabletext/react": "8.0.1",
-    "@sanity/client": "3.4.1",
-    "@sanity/image-url": "1.0.1",
+    "@sanity/client": "8.2.0",
+    "@sanity/image-url": "2.1.1",
     "next": "16.3.2",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -3,8 +3,8 @@ import FirmSection from "../components/layout/firm-section";
 
 import CONTENT from "../content/aboutContent.json";
 import useLocale from "../hooks/useLocale";
-import { plainText } from "../libs/expertise";
 import { fetchHome } from "../libs/page-content";
+import { plainText } from "../libs/plain-text";
 import { staticPageProps } from "../libs/static-page-props";
 import type { HomeDocument } from "../libs/types";
 

--- a/pages/api/llms.ts
+++ b/pages/api/llms.ts
@@ -1,8 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import type { AgentLabels } from "../../libs/agent-context";
 import { agentContext } from "../../libs/agent-context";
-import { fetchExpertise, plainText } from "../../libs/expertise";
+import { fetchExpertise } from "../../libs/expertise";
 import { leadSentence, llmsTxt } from "../../libs/llms-txt";
+import { plainText } from "../../libs/plain-text";
 import { methodNotAllowed, unexpectedQuery } from "../../libs/query-guard";
 import { pageUrl } from "../../libs/site-url";
 import type { LinkItem, Locale } from "../../libs/types";

--- a/pages/api/markdown.ts
+++ b/pages/api/markdown.ts
@@ -5,7 +5,7 @@ import publicationsContent from "../../content/publicationsContent.json";
 import { varyWithAccept } from "../../libs/accept";
 import type { AgentContext } from "../../libs/agent-context";
 import { agentContext } from "../../libs/agent-context";
-import { fetchExpertise, plainText } from "../../libs/expertise";
+import { fetchExpertise } from "../../libs/expertise";
 import { fetchContact, fetchHome, fetchLegal } from "../../libs/page-content";
 import {
 	aboutMarkdown,
@@ -20,6 +20,7 @@ import {
 	publicationsIndexMarkdown,
 	unavailableMarkdown,
 } from "../../libs/page-markdown";
+import { plainText } from "../../libs/plain-text";
 import { groupPublications, seriesOf, splitTitle } from "../../libs/publication-fields";
 import { fetchPublicationBody, fetchPublications } from "../../libs/publications";
 import { methodNotAllowed, unexpectedQuery } from "../../libs/query-guard";

--- a/pages/api/sitemap.ts
+++ b/pages/api/sitemap.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import clientApi from "../../libs/clientApi";
-import { expertiseSlug } from "../../libs/expertise";
+import { expertiseSlug } from "../../libs/expertise-list";
 import EXPERTISE_PAIRS from "../../libs/expertisePairs";
 import { fetchPublications } from "../../libs/publications";
 import { methodNotAllowed } from "../../libs/query-guard";

--- a/pages/articles/[id].tsx
+++ b/pages/articles/[id].tsx
@@ -1,6 +1,7 @@
 import type { GetServerSideProps } from "next";
 import { withLocale } from "../../libs/localePath";
-import { fetchPublicationById, otherLocale } from "../../libs/publications";
+import { otherLocale } from "../../libs/publication-fields";
+import { fetchPublicationById } from "../../libs/publications";
 import { resolveLocale } from "../../libs/site-url";
 import type { Locale } from "../../libs/types";
 

--- a/pages/expertise/[slug].tsx
+++ b/pages/expertise/[slug].tsx
@@ -2,7 +2,8 @@ import type { GetStaticPaths } from "next";
 import type { ExpertisePageProps } from "../../components/layout/expertise-page";
 import ExpertisePage from "../../components/layout/expertise-page";
 import organizationContent from "../../content/organizationContent.json";
-import { fetchExpertise, plainText } from "../../libs/expertise";
+import { fetchExpertise } from "../../libs/expertise";
+import { plainText } from "../../libs/plain-text";
 import { LOCALES, resolveLocale } from "../../libs/site-url";
 import { staticPageProps } from "../../libs/static-page-props";
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,7 +4,7 @@ import FirmSection from "../components/layout/firm-section";
 import footerContent from "../content/footerContent.json";
 import useLocale from "../hooks/useLocale";
 import { splitAddress } from "../libs/address";
-import { expertiseSlug } from "../libs/expertise";
+import { expertiseSlug } from "../libs/expertise-list";
 import { fetchHome } from "../libs/page-content";
 import { staticPageProps } from "../libs/static-page-props";
 import type { HomeDocument } from "../libs/types";

--- a/pages/publications/[slug].tsx
+++ b/pages/publications/[slug].tsx
@@ -2,15 +2,10 @@ import type { GetStaticPaths, GetStaticProps } from "next";
 import type { PublicationPageProps } from "../../components/layout/publication-page";
 import PublicationPage from "../../components/layout/publication-page";
 import organizationContent from "../../content/organizationContent.json";
-import { plainText } from "../../libs/expertise";
 import { withLocale } from "../../libs/localePath";
-import {
-	fetchPublicationBody,
-	fetchPublications,
-	otherLocale,
-	seriesOf,
-	splitTitle,
-} from "../../libs/publications";
+import { plainText } from "../../libs/plain-text";
+import { otherLocale, seriesOf, splitTitle } from "../../libs/publication-fields";
+import { fetchPublicationBody, fetchPublications } from "../../libs/publications";
 import { LOCALES, resolveLocale } from "../../libs/site-url";
 import type { Locale, PageSeo } from "../../libs/types";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -476,6 +476,16 @@
   resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.3.2.tgz#53d7b47708c2979bd7c8c468e0424212a9b1bee7"
   integrity sha512-H4Y2o2/JcHu8LtwzD5CXfHhwxwz8gfsx2HXDEw46Mtev5xHnEmB7HNtZtmriw5ReUOjRtcDqo7XSbU01FT9NlA==
 
+"@noble/ed25519@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@noble/ed25519/-/ed25519-3.1.0.tgz#f72f53c9ef2a3feebd59caee0bb5b2d4f766aa08"
+  integrity sha512-pfcObRY3CtvwfaG9Mt5XqZdKmAQppl37tHUeuBhDUbiwJBCVY4/A4lbMvb1xKhMDx96AqAqZpMWuBX1HulhX4g==
+
+"@noble/hashes@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-2.3.0.tgz#505fd39c3134a37e67c8c4e6c6049a496154879c"
+  integrity sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -685,34 +695,31 @@
   resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz#e3fcee093fbb5ce765e1ad088ff4de2889f6f9be"
   integrity sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==
 
-"@sanity/client@3.4.1":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@sanity/client/-/client-3.4.1.tgz#d1bd02bafc50eb0aac8d5b6fab942da52549652f"
-  integrity sha512-WSvnroCHqboUeyY0nl71vDPKmfurXI0mtqdNDb5u8MW00CAHRyCt1+Sgy39D/g+6R35FYniV31vTSTo3ofim0A==
+"@sanity/client@8.2.0":
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/@sanity/client/-/client-8.2.0.tgz#6ad43e55826a3c106f0972410a560344fb890e5b"
+  integrity sha512-SK2o8uh9ayAYAHJtKvd3r78Y5QHlV6RA1H249rYXtm71rdvp4dVvQyf3E/QtYVaeIhrWufK1Mh7sbX6FDVLtWQ==
   dependencies:
-    "@sanity/eventsource" "^4.0.0"
-    get-it "^6.1.1"
-    make-error "^1.3.0"
-    object-assign "^4.1.1"
-    rxjs "^6.0.0"
+    eventsource "^5.1.0"
+    get-it "^9.5.0"
+    nanoid "^6.0.1"
+    obug "^2.1.4"
+    rxjs "^7.8.2"
 
-"@sanity/eventsource@^4.0.0":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@sanity/eventsource/-/eventsource-4.1.1.tgz#9a86c5d3dba4c8579cef813bf8bc63e05134413e"
-  integrity sha512-4RpexVqD+hbIXDgFLgWq/vSJWHNEBbc9eGa96ear/3ADFhMQx+QG4Q7r3QmQkB2t7LfUrrJfMQn9sMwaBTlurg==
+"@sanity/image-url@2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@sanity/image-url/-/image-url-2.1.1.tgz#58fc012e297e997792d94dc5f081424967c18aa7"
+  integrity sha512-qVXsF1teWR6FO3ZFAz46HDcRU+E6EQkpyncPnkGOzeJ1PgnaOiWMVbiSrZtX10s3txzzu/tAjKwbxbGHfDWgGw==
   dependencies:
-    event-source-polyfill "1.0.31"
-    eventsource "2.0.2"
+    "@sanity/signed-urls" "^2.0.2"
 
-"@sanity/image-url@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@sanity/image-url/-/image-url-1.0.1.tgz#960d649b2f4396da0adb31cf94503c929495cea0"
-  integrity sha512-AdKQ3zMk7WdoNwoJPrAvQhW+kUtBldBX0nHtnGy+rwmgsCQ0rAXasrgH43Fhmsp/yB6piiq+F2d5qEuBFsdQVg==
-
-"@sanity/timed-out@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@sanity/timed-out/-/timed-out-4.0.2.tgz#c9f61f9a1609baa1eb3e4235a24ea2a775022cdf"
-  integrity sha512-NBDKGj14g9Z+bopIvZcQKWCzJq5JSrdmzRR1CS+iyA3Gm8SnIWBfZa7I3mTg2X6Nu8LQXG0EPKXdOGozLS4i3w==
+"@sanity/signed-urls@^2.0.2":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@sanity/signed-urls/-/signed-urls-2.0.5.tgz#26203949efd357e278daec6926aaea2b759a8856"
+  integrity sha512-kg+LrXyk8tYNuCZnXrSRpTKR6dkbjkfBimGhqUs93VlfhSr56NkbS9N6zXqYRTg2mwbPYd/CAQHNX3SsXJgPcg==
+  dependencies:
+    "@noble/ed25519" "^3.1.0"
+    "@noble/hashes" "^2.3.0"
 
 "@standard-schema/spec@^1.1.0":
   version "1.1.0"
@@ -1029,11 +1036,6 @@ caniuse-lite@^1.0.30001579:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz#4970b477dea3278374de9bc43aa8f5d39fc3cda2"
   integrity sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==
 
-capture-stack-trace@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/capture-stack-trace/-/capture-stack-trace-1.0.2.tgz#1c43f6b059d4249e7f3f8724f15f048b927d3a8a"
-  integrity sha512-X/WM2UQs6VMHUtjUDnZTRI+i1crWteJySFzr9UpGoQa4WQffXVTTXuekjl7TjZRlcF2XfjgITT0HxZ9RnxeT0w==
-
 chai@^6.2.2:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/chai/-/chai-6.2.2.tgz#ae41b52c9aca87734505362717f3255facda360e"
@@ -1055,18 +1057,6 @@ convert-source-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
-
-core-util-is@~1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
-  integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
-
-create-error-class@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/create-error-class/-/create-error-class-3.0.2.tgz#06be7abef947a3f14a30fd610671d401bca8b7b6"
-  integrity sha512-gYTKKexFO3kh200H1Nit76sRwRtOY32vQd3jpAQKpLtZqyNsSQNfI4N7o3eP2wUjV35pTWKRYqFUDBvUha/Pkw==
-  dependencies:
-    capture-stack-trace "^1.0.0"
 
 cross-spawn@^7.0.6:
   version "7.0.6"
@@ -1103,13 +1093,6 @@ data-urls@^7.0.0:
     whatwg-mimetype "^5.0.0"
     whatwg-url "^16.0.0"
 
-debug@^2.6.8:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
-  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
-  dependencies:
-    ms "2.0.0"
-
 debug@^4.3.1, debug@^4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
@@ -1128,13 +1111,6 @@ decimal.js@^10.6.0:
   version "10.6.0"
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.6.0.tgz#e649a43e3ab953a72192ff5983865e509f37ed9a"
   integrity sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==
-
-decompress-response@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-6.0.0.tgz#ca387612ddb7e104bd16d85aab00d5ecf09c66fc"
-  integrity sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==
-  dependencies:
-    mimic-response "^3.1.0"
 
 deep-is@^0.1.3:
   version "0.1.4"
@@ -1272,15 +1248,17 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-event-source-polyfill@1.0.31:
-  version "1.0.31"
-  resolved "https://registry.yarnpkg.com/event-source-polyfill/-/event-source-polyfill-1.0.31.tgz#45fb0a6fc1375b2ba597361ba4287ffec5bf2e0c"
-  integrity sha512-4IJSItgS/41IxN5UVAVuAyczwZF7ZIEsM1XAoUzIHA6A+xzusEZUutdXz2Nr+MQPLxfTiCvqE79/C8HT8fKFvA==
+eventsource-parser@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/eventsource-parser/-/eventsource-parser-4.1.0.tgz#5a16373feb67451c8ba5fcf25556db46152feebc"
+  integrity sha512-+DHvQ1wLO//MK+1OZgcuXCbZFKgu3YjKPJt7n98rxX8vezL0ni+7s3ZQiM8bJkUEOk7MsuCycrPLj0FzUNf7Og==
 
-eventsource@2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-2.0.2.tgz#76dfcc02930fb2ff339520b6d290da573a9e8508"
-  integrity sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==
+eventsource@^5.1.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-5.1.1.tgz#e40fa9b09b38b5af7a8dccb800aec5cd4b3bf113"
+  integrity sha512-onrlI7l612Ee3xnBqZNTq4djf6Fho/0yIpO/rYjRG/FzjMyPJquNx9SS3QyjglnVFxwxrube1XmX41zB+0Rdgw==
+  dependencies:
+    eventsource-parser "^4.1.0"
 
 expect-type@^1.3.0:
   version "1.4.0"
@@ -1360,52 +1338,17 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.4.4.tgz#aeeca2a506303f0cee61c59e6c9f2a88d2f29fc6"
   integrity sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==
 
-follow-redirects@^1.2.4:
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
-  integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
-
-form-urlencoded@^2.0.7:
-  version "2.0.9"
-  resolved "https://registry.yarnpkg.com/form-urlencoded/-/form-urlencoded-2.0.9.tgz#ea07c5dbd9aa739275d53ec5c671ea069fe7d597"
-  integrity sha512-fWUzNiOnYa126vFAT6TFXd1mhJrvD8IqmQ9ilZPjkLYQfaRreBr5fIUoOpPlWtqaAG64nzoE7u5zSetifab9IA==
-
-from2@^2.1.1:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/from2/-/from2-2.3.0.tgz#8bfb5502bde4a4d36cfdeea007fcca21d7e382af"
-  integrity sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==
-  dependencies:
-    inherits "^2.0.1"
-    readable-stream "^2.0.0"
-
 fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
-get-it@^6.1.1:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/get-it/-/get-it-6.1.1.tgz#793100756a800808abc8f0d981ca5c7b90fe343d"
-  integrity sha512-2835L9lb4NAgjAbFOMMOm2XDSgj+lWmmCQv40A5rE7zZoIdM2+yk7Ie+sBD3T5lHW/Dw5IFFHyx16oQGpAo4hQ==
+get-it@^9.5.0:
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/get-it/-/get-it-9.5.1.tgz#a619d674fc72f0421ca85933957f9656b5056cc9"
+  integrity sha512-XCVgepH7ROA/VEW4iaorxII3ZqQt7bqNhRNdeOklqwWsl7iGuJCGL7jxkUzcWVpK5zsYr0WaMqeXrIfeL02Uig==
   dependencies:
-    "@sanity/timed-out" "^4.0.2"
-    create-error-class "^3.0.2"
-    debug "^2.6.8"
-    decompress-response "^6.0.0"
-    follow-redirects "^1.2.4"
-    form-urlencoded "^2.0.7"
-    into-stream "^3.1.0"
-    is-plain-object "^2.0.4"
-    is-retry-allowed "^1.1.0"
-    is-stream "^1.1.0"
-    nano-pubsub "^1.0.2"
-    object-assign "^4.1.1"
-    parse-headers "^2.0.4"
-    progress-stream "^2.0.0"
-    same-origin "^0.1.1"
-    simple-concat "^1.0.1"
-    tunnel-agent "^0.6.0"
-    url-parse "^1.1.9"
+    undici "^7.22.0"
 
 glob-parent@^5.1.2:
   version "5.1.2"
@@ -1448,19 +1391,6 @@ indent-string@^4.0.0:
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
   integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
 
-inherits@^2.0.1, inherits@~2.0.3:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
-  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
-
-into-stream@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/into-stream/-/into-stream-3.1.0.tgz#96fb0a936c12babd6ff1752a17d05616abd094c6"
-  integrity sha512-TcdjPibTksa1NQximqep2r17ISRiNE9fwlfbg3F8ANdvP5/yrFTew86VcO//jk4QTaMlbjypPBq76HN2zaKfZQ==
-  dependencies:
-    from2 "^2.1.1"
-    p-is-promise "^1.1.0"
-
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
@@ -1478,42 +1408,15 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
-is-plain-object@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
-  integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
-  dependencies:
-    isobject "^3.0.1"
-
 is-potential-custom-element-name@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5"
   integrity sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==
 
-is-retry-allowed@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz#d778488bd0a4666a3be8a1482b9f2baafedea8b4"
-  integrity sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==
-
-is-stream@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
-  integrity sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==
-
-isarray@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
-  integrity sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==
-
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
-
-isobject@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
-  integrity sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==
 
 js-tokens@^4.0.0:
   version "4.0.0"
@@ -1675,11 +1578,6 @@ magic-string@^0.30.21:
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.5.5"
 
-make-error@^1.3.0:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
-  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
-
 mdn-data@2.27.1:
   version "2.27.1"
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.27.1.tgz#e37b9c50880b75366c4d40ac63d9bbcacdb61f0e"
@@ -1698,11 +1596,6 @@ micromatch@^4.0.4:
     braces "^3.0.2"
     picomatch "^2.3.1"
 
-mimic-response@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
-  integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
-
 min-indent@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
@@ -1715,11 +1608,6 @@ minimatch@^10.2.2, minimatch@^10.2.4, minimatch@^10.2.5:
   dependencies:
     brace-expansion "^5.0.8"
 
-ms@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
-  integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
-
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
@@ -1730,15 +1618,15 @@ ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-nano-pubsub@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/nano-pubsub/-/nano-pubsub-1.0.2.tgz#34ce776f7af959915b8f7acfe8dd6b9c66f3bde9"
-  integrity sha512-HtPs1RbULM/z8wt3BbeeZlxVNiJbl+zQAwwrbc0KAq5NHaCG3MmffOVCpRhNTs+TK67MdN6aZ+5wzPtRZvME+w==
-
 nanoid@^3.3.16, nanoid@^3.3.17:
   version "3.3.18"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.18.tgz#f66a2de1199ffde0fcf21c8a5f13106b1c081913"
   integrity sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==
+
+nanoid@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-6.0.1.tgz#a04a2304f05b620c600ae8464d94c325ceeebd35"
+  integrity sha512-3wVS3i51pE2pi1k5FFL/95BGfVS0kSsvDVuGXHOtxox/TywUmtgq+3qiTOTbs9J7KfHaXPiN171k/A6dBnaXFw==
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -1772,12 +1660,7 @@ node-addon-api@^7.0.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-7.1.1.tgz#1aba6693b0f255258a049d621329329322aad558"
   integrity sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==
 
-object-assign@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
-  integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
-
-obug@^2.1.1:
+obug@^2.1.1, obug@^2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/obug/-/obug-2.1.4.tgz#9090d8a548a522517915d2aa6aae907197ac6cf8"
   integrity sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==
@@ -1794,11 +1677,6 @@ optionator@^0.9.3:
     type-check "^0.4.0"
     word-wrap "^1.2.5"
 
-p-is-promise@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-1.1.0.tgz#9c9456989e9f6588017b0434d56097675c3da05e"
-  integrity sha512-zL7VE4JVS2IFSkR2GQKDSPEVxkoH43/p7oEnwpdCndKYJO0HVeRB7fA8TJwuLOTBREtK0ea8eHaxdwcpob5dmg==
-
 p-limit@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
@@ -1812,11 +1690,6 @@ p-locate@^5.0.0:
   integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
   dependencies:
     p-limit "^3.0.2"
-
-parse-headers@^2.0.4:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/parse-headers/-/parse-headers-2.0.6.tgz#7940f0abe5fe65df2dd25d4ce8800cb35b49d01c"
-  integrity sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A==
 
 parse5@^8.0.1:
   version "8.0.1"
@@ -1887,19 +1760,6 @@ pretty-format@^27.0.2:
     ansi-styles "^5.0.0"
     react-is "^17.0.1"
 
-process-nextick-args@~2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
-  integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
-
-progress-stream@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/progress-stream/-/progress-stream-2.0.0.tgz#fac63a0b3d11deacbb0969abcc93b214bce19ed5"
-  integrity sha512-xJwOWR46jcXUq6EH9yYyqp+I52skPySOeHfkxOZ2IY1AiBi/sFJhbhAKHoV3OTw/omQ45KTio9215dRJ2Yxd3Q==
-  dependencies:
-    speedometer "~1.0.0"
-    through2 "~2.0.3"
-
 punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
@@ -1909,11 +1769,6 @@ punycode@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
-
-querystringify@^2.1.1:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
-  integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -1942,19 +1797,6 @@ react@19.2.8:
   resolved "https://registry.yarnpkg.com/react/-/react-19.2.8.tgz#a80663dbb58d69c6fe3fd291d3cb324e8a7dff2d"
   integrity sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==
 
-readable-stream@^2.0.0, readable-stream@~2.3.6:
-  version "2.3.8"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.8.tgz#91125e8042bba1b9887f49345f6277027ce8be9b"
-  integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.3"
-    isarray "~1.0.0"
-    process-nextick-args "~2.0.0"
-    safe-buffer "~5.1.1"
-    string_decoder "~1.1.1"
-    util-deprecate "~1.0.1"
-
 readdirp@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-5.1.1.tgz#520bca06f9d1ae1b96cc0800dbe84b983d19422c"
@@ -1972,11 +1814,6 @@ require-from-string@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
-
-requires-port@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
-  integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
 
 reusify@^1.0.4:
   version "1.0.4"
@@ -2014,27 +1851,12 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-rxjs@^6.0.0:
-  version "6.6.7"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
-  integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
+rxjs@^7.8.2:
+  version "7.8.2"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.2.tgz#955bc473ed8af11a002a2be52071bf475638607b"
+  integrity sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==
   dependencies:
-    tslib "^1.9.0"
-
-safe-buffer@^5.0.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
-  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
-
-safe-buffer@~5.1.0, safe-buffer@~5.1.1:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
-  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
-
-same-origin@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/same-origin/-/same-origin-0.1.1.tgz#c2287d3192577df517acbbd6d1451a9c3c3914f5"
-  integrity sha512-effkSW9cap879l6CVNdwL5iubVz8tkspqgfiqwgBgFQspV7152WHaLzr5590yR8oFgt7E1d4lO09uUhtAgUPoA==
+    tslib "^2.1.0"
 
 sass@1.103.1:
   version "1.103.1"
@@ -2116,11 +1938,6 @@ siginfo@^2.0.0:
   resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
   integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
 
-simple-concat@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.1.tgz#f46976082ba35c2263f1c8ab5edfe26c41c9552f"
-  integrity sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==
-
 "source-map-js@>=0.6.2 <2.0.0":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
@@ -2131,11 +1948,6 @@ source-map-js@^1.2.1:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
-speedometer@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/speedometer/-/speedometer-1.0.0.tgz#cd671cb06752c22bca3370e2f334440be4fc62e2"
-  integrity sha512-lgxErLl/7A5+vgIIXsh9MbeukOaCb2axgQ+bKCdIE+ibNT4XNYGNCR1qFEGq6F+YDASXK3Fh/c5FgtZchFolxw==
-
 stackback@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
@@ -2145,13 +1957,6 @@ std-env@^4.0.0-rc.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/std-env/-/std-env-4.2.0.tgz#8ebe0ec60485668ab47227b312f4254cdf80c9d3"
   integrity sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==
-
-string_decoder@~1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
-  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
-  dependencies:
-    safe-buffer "~5.1.0"
 
 strip-indent@^3.0.0:
   version "3.0.0"
@@ -2171,14 +1976,6 @@ symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
-
-through2@~2.0.3:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
-  integrity sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==
-  dependencies:
-    readable-stream "~2.3.6"
-    xtend "~4.0.1"
 
 tinybench@^2.9.0:
   version "2.9.0"
@@ -2241,27 +2038,15 @@ ts-api-utils@^2.5.0:
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-2.5.0.tgz#4acd4a155e22734990a5ed1fe9e97f113bcb37c1"
   integrity sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==
 
-tslib@^1.9.0:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
-  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+tslib@^2.1.0, tslib@^2.8.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tslib@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
-
-tslib@^2.8.0:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
-  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
-
-tunnel-agent@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
-  integrity sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==
-  dependencies:
-    safe-buffer "^5.0.1"
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
@@ -2280,6 +2065,11 @@ undici-types@~7.18.0:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.18.2.tgz#29357a89e7b7ca4aef3bf0fd3fd0cd73884229e9"
   integrity sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==
 
+undici@^7.22.0:
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.29.0.tgz#ae0f6f62e06e057a9cbb7b2b5fde2bb74f791b8f"
+  integrity sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==
+
 undici@^8.9.0:
   version "8.10.0"
   resolved "https://registry.yarnpkg.com/undici/-/undici-8.10.0.tgz#67ed7c4087f0f40fba7bef3a46f2be80572f2473"
@@ -2291,19 +2081,6 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
-
-url-parse@^1.1.9:
-  version "1.5.10"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
-  integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
-  dependencies:
-    querystringify "^2.1.1"
-    requires-port "^1.0.0"
-
-util-deprecate@~1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
-  integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
 "vite@^6.0.0 || ^7.0.0 || ^8.0.0":
   version "8.2.2"
@@ -2408,11 +2185,6 @@ xmlchars@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
-
-xtend@~4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
-  integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
`@sanity/client` was on **3.4.1, published September 2022**, and it was shipping to the browser. It is on 8.2.0 now, `@sanity/image-url` on 2.1.1, and neither reaches a visitor.

## The bump

`createClient`, the named export; the default export still resolves but is deprecated. `apiVersion` pinned to `2025-02-19` — the version where the default perspective changed from `raw` to `published` — with `perspective` set explicitly beside it, so a later date cannot silently start serving drafts. Only the publications query filters `drafts.**` itself; a `[0]` projection on any other document would otherwise hand a page whichever copy came back first. `yarn.lock` loses 297 lines.

Verified on its own before anything else changed: byte-identical output.

## The client was in the browser bundle

72K of `@sanity/client`, `rxjs` and `get-it` on 7 of 9 pages, for an HTTP client the browser never calls. Three import paths, all the same mistake — a pure function borrowed from a module that happens to build a client:

| Path | Fix |
|---|---|
| `components/ui/sanityImage.tsx` → `SANITY_PROJECT` from `libs/clientApi` | the constant moves to `libs/sanity-image.ts`, beside the reference parser, which is the rest of what addresses the image CDN |
| five components → `formatDate`, `isPress`, `splitTitle`, `groupPublications`, `pagerFor` from `libs/publications`, which re-exported them from `libs/publication-fields` "so call sites import one module" | the re-export is gone; they import the pure module |
| `plainText` living in `libs/expertise.ts`, which has nothing to do with expertise | `libs/plain-text.ts`, with the seven tests it could not have before |

**First-load JavaScript, gzipped:**

```
 148K ->  125K  -23K  /
 146K ->  124K  -22K  /about
 150K ->  127K  -23K  /expertise
 150K ->  127K  -23K  /expertise/[slug]
 146K ->  124K  -22K  /legal
 137K ->  114K  -23K  /publications
 151K ->  129K  -22K  /publications/[slug]
```

15% of the home page.

## The guard

`libs/no-client-in-components.test.ts` walks the import graph from every file under `components/` and fails with the chain that reaches the client:

```
AssertionError: expected [ Array(1) ] to strictly equal []
+   "components/layout/publications-index.tsx -> libs/publications.ts -> libs/clientApi.ts",
```

That output is from deliberately reintroducing one re-export, which is how the test was checked. This class of regression is invisible in a diff and invisible in a screenshot; it shows up only as a chunk that grew.

## Verification

Golden files from the pre-change build, diffed after: 13 markdown documents, both `llms.txt` editions, `sitemap.xml`, and the head annotations plus JSON-LD of four pages are **byte-identical**; six page screenshots at 1440x1000 are **pixel-identical** (RMSE 0).

`yarn verify`: Biome clean (10 pre-existing warnings), typecheck clean, 162 tests in 21 files pass. `yarn build` green, 53 static pages.

## Still open

`libs/types.ts` describes the CMS documents by hand and `clientApi.fetch<T>()` asserts them unchecked — the one assertion the no-`as` rule cannot see. Parsing the projections with zod, and deriving the types from those schemas, is the natural next step; it is a separate PR so this one stays a bump plus a bundle fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)