### PR TITLE
fix: take back the 6rem the global section padding added to every ISKA block

### DIFF
--- a/pages/iska.module.scss
+++ b/pages/iska.module.scss
@@ -56,8 +56,11 @@
   animation: rise 0.6s $ease $stagger both;
 }
 
+// globals.scss gives every `section` `padding: $space-7 0`; overriding only the
+// bottom leaves that 6rem top in place and separated two blocks by 12rem rather
+// than the 6rem below. The padding-bottom owns the rhythm here.
 .block {
-  padding-bottom: $space-7;
+  padding: 0 0 $space-7 0;
   animation: rise 0.5s $ease $stagger both;
 }
 


### PR DESCRIPTION
## Motivation

The three numbered blocks on `/iska` sat ~192px apart, so the page read as three
islands adrift rather than as the 6rem rhythm the rest of the site runs on.

`styles/globals.scss` gives **every** `<section>` `padding: $space-7 0`, top and
bottom. `.block` overrode only `padding-bottom`, and a class beats an element
selector for that one longhand while the `padding-top` from the global shorthand
survives underneath. So each block computed to 6rem top *and* 6rem bottom, and
two blocks ended up 12rem apart rather than the 6rem the module declares.

The emitted stylesheet before the change:

```
section{padding:6rem 0}                          /* globals */
.iska-…__block{padding-bottom:6rem}              /* no padding-top of its own */
```

It went lopsided at the breakpoints too, because the two overrides move at
different widths:

| Width | top | bottom | gap between blocks |
|---|---|---|---|
| >=992px | 6rem (globals) | 6rem | **12rem** |
| 768-992px | 6rem (globals) | 4rem (`.block` md) | **10rem**, lopsided |
| <768px | 3rem (globals sm) | 4rem (`.block` md) | **7rem**, lopsided |

The same trap is already documented and fixed one file over, in
`components/layout/publications-index.module.scss` ("~18rem rather than the 6rem
the margin declares"). `/iska` was the last `<section>` in the app that
overrode the global padding in part rather than whole: `contact`, `legal`,
`expertise-page` and `firm-section` all either take it entirely or replace it
entirely.

## Solution

One declaration. `.block` now sets the whole shorthand, so the 0 top is explicit
and nothing is left for the global rule to fill in:

```scss
.block {
  padding: 0 0 $space-7 0;
}
```

The `@media (max-width: $breakpoint-md)` rule is untouched: it keeps
`padding-bottom: $space-6` and now inherits `padding-top: 0` from the base rule,
which is what straightens the two lopsided breakpoints into a clean 4rem.

The rhythm that results is 6rem from the lede to block 01, 6rem between blocks
and 6rem from block 03 to the footer, which matches
`publications-index.module.scss`'s `margin-bottom: $space-7` between sections.
Nothing in `pages/iska.tsx` changes, and the comment above the rule is there so
the next person overriding a `section` padding does not lose the same afternoon.

## Verification

- Emitted CSS on a dev server built from this branch: `.iska-…__block{padding:0 0 6rem}`,
  and `{padding-bottom:4rem}` inside the 992 media block.
- Headless screenshots at 1440 and 900 before and after: the page loses ~290px of
  height and the blocks land on the 6rem rhythm.
- `yarn verify`: biome 10 warnings, all pre-existing in `libs/proxy-route.ts` and
  `pages/api/markdown.ts`; eslint clean; `tsc --noEmit` clean; 167 tests in 21
  files pass. SCSS is not covered by any of the four, so the screenshots and the
  emitted-CSS check are the real assertion here.