### PR TITLE
feat: edit the site from inside the Studio, on the page

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,7 +1,15 @@
 "$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
 
 [scripts]
-setup = "pnpm install"
+# Install both workspaces, then make sure the site can find its env.
+#
+# Next resolves .env from its own project directory, so the file has to be at
+# apps/web/.env or it is read by nothing: the symptom is `Configuration must
+# contain projectId` and a 500 on every page. .worktreeinclude copies both
+# locations because the main checkout still keeps it at the root, and this
+# promotes that copy when the apps/web one is absent. It never overwrites, and
+# it is a no-op once the main checkout moves the file for good.
+setup = "pnpm install && { [ -f apps/web/.env ] || [ ! -f .env ] || cp .env apps/web/.env; }"
 
 # Each workspace is given ten ports from $CONDUCTOR_PORT and the two servers
 # take one each, so two workspaces can run side by side. Nothing else is

--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -18,8 +18,13 @@ available_in = ["local"]
 default = true
 icon = "play"
 
+# SANITY_STUDIO_PREVIEW_URL points Presentation at the site running in this same
+# workspace, on $CONDUCTOR_PORT. Without it the Studio would frame production
+# while you edit locally, and the draft-mode handshake would set its cookie on
+# the wrong origin. Vite only exposes SANITY_STUDIO_* to the config, which is
+# what apps/studio/sanity.config.js reads.
 [scripts.run.studio]
-command = "pnpm --filter studio dev --port $((CONDUCTOR_PORT + 1))"
+command = "SANITY_STUDIO_PREVIEW_URL=http://localhost:$CONDUCTOR_PORT pnpm --filter studio dev --port $((CONDUCTOR_PORT + 1))"
 available_in = ["local"]
 icon = "database"
 

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -5,3 +5,9 @@
 # own project directory, which is apps/web now, not the repository root, and a
 # copy left at the root is read by nothing.
 apps/web/.env*
+
+# The root copy is here because that is where the main checkout still keeps it,
+# and a pattern that selects nothing is a workspace that comes up with no env
+# and 500s on every page. Copying it is only half the job: the setup script in
+# .conductor/settings.toml is what puts it where Next will look.
+.env*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,16 @@ Both halves point at Sanity project `46fx2dmc`, dataset `production`. The site
 reads the id from `NEXT_PUBLIC_SANITY_ID`; the studio hardcodes it in
 `sanity.cli.js` and `sanity.config.js`.
 
+The second seam runs the other way, and it is a URL rather than a type.
+`presentationTool` in `apps/studio/sanity.config.js` frames the site and calls
+`/api/draft` on it to hand over a one-time preview secret;
+`apps/web/pages/api/draft.ts` is what answers. Nothing validates that pairing
+either: rename the route and the Studio keeps offering a preview button that
+401s. `SANITY_STUDIO_PREVIEW_URL` chooses which site gets framed, defaulting to
+production, and `.conductor/settings.toml` points it at the local one. The site
+side of it is documented under "Draft mode, and editing on the page" in
+`apps/web/CLAUDE.md`.
+
 ## Conductor
 
 `.conductor/settings.toml` and `.worktreeinclude` at the root configure the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,10 +88,19 @@ both servers and cannot give them different ports: `web` takes
 `$CONDUCTOR_PORT` is unset in a cloud workspace and both servers would fall
 back to their default port and collide.
 
-`.worktreeinclude` copies `apps/web/.env*`, not a root `.env`. Next resolves
-its env file from its own project directory, so a copy at the repo root is read
-by nothing. **The main checkout has to have the file at `apps/web/.env` for
-there to be anything to copy.**
+Next resolves its env file from its own project directory, so the site's env has
+to end up at `apps/web/.env`; a copy at the repo root is read by nothing, and
+the symptom is `Configuration must contain projectId` and a 500 on every page.
+
+Two things get it there, because the main checkout still keeps the file at the
+root. `.worktreeinclude` copies **both** locations, since a pattern that selects
+nothing is a workspace that comes up with no env at all. Then the `setup` script
+promotes the root copy to `apps/web/.env` when that one is absent. It never
+overwrites, so a workspace that received the real thing keeps it, and the whole
+step becomes a no-op the day the main checkout moves the file for good.
+
+`SANITY_TOKEN` rides along in the same file. Only draft mode reads it, so a
+workspace without it runs the published site fine.
 
 The Mac app reads the shared `settings.toml` from the default branch on the
 remote, so none of this takes effect until it is on `main`.

--- a/apps/studio/CLAUDE.md
+++ b/apps/studio/CLAUDE.md
@@ -17,6 +17,15 @@ dataset `production`, deployed to Sanity's own hosting rather than to Vercel.
 | Tests | `node --test`. No Vitest, no test framework |
 | Deploy | `pnpm --filter studio deploy`, pinned to the existing studio by `appId` |
 
+`presentationTool` puts the site in an iframe beside the form that feeds it, and
+turns every string on the page into a click target for its field. That needs
+`/api/draft` on the other side (`apps/web/pages/api/draft.ts`) and a
+`SANITY_TOKEN` there; without them Presentation still frames the site, but as a
+preview of what is already published. `SANITY_STUDIO_PREVIEW_URL` chooses which
+site, defaulting to production. Vite only exposes `SANITY_STUDIO_*`, which is
+why it is read off `import.meta.env` rather than `process.env`, a global this
+Studio's ESLint config does not know.
+
 ```bash
 pnpm dev          # sanity dev, :3333
 pnpm build        # sanity build

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -21,7 +21,7 @@
     "react-dom": "catalog:",
     "react-icons": "5.7.0",
     "sanity": "6.10.1",
-    "styled-components": "6.5.3"
+    "styled-components": "catalog:"
   },
   "devDependencies": {
     "@sanity/eslint-config-studio": "7.0.0",

--- a/apps/studio/sanity.config.js
+++ b/apps/studio/sanity.config.js
@@ -1,5 +1,6 @@
 import {defineConfig} from 'sanity'
 import {structureTool} from 'sanity/structure'
+import {presentationTool} from 'sanity/presentation'
 import {visionTool} from '@sanity/vision'
 
 import {schemaTypes} from './schemas'
@@ -11,7 +12,31 @@ export default defineConfig({
   projectId: '46fx2dmc',
   dataset: 'production',
 
-  plugins: [structureTool(), visionTool()],
+  plugins: [
+    structureTool(),
+    // The site, in an iframe beside the form that feeds it. `previewMode.enable`
+    // is the handshake: Presentation mints a one-time secret in the dataset and
+    // calls that route with it, which is what lets the site show unpublished
+    // drafts and stega-encode an edit link into every string it renders.
+    //
+    // The route is the other half of this change, in the other workspace:
+    // apps/web/pages/api/draft.ts. Nothing validates one against the other, so
+    // if that route moves, this is the string to update.
+    //
+    // `initial` rather than the `origin`/`preview` pair, which
+    // `PreviewUrlResolverOptions` deprecated in 6.9. `import.meta.env` rather
+    // than `process.env`, which is not a global @sanity/eslint-config-studio
+    // knows and which Vite does not populate; SANITY_STUDIO_* is where Vite puts
+    // them. The default is production, so a deployed Studio needs no env at all;
+    // .conductor/settings.toml sets it to the local site in a workspace.
+    presentationTool({
+      previewUrl: {
+        initial: import.meta.env.SANITY_STUDIO_PREVIEW_URL || 'https://www.ouaknine-avocats.com',
+        previewMode: {enable: '/api/draft'},
+      },
+    }),
+    visionTool(),
+  ],
 
   schema: {
     types: schemaTypes,

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -204,6 +204,8 @@ typechecks fine, then fails at "Collecting page data". Pages 500 in dev.
 If you have the value, put `.env.local` at **`apps/web/.env.local`**: Next reads
 it from the app directory, not from the repo root. Conductor's Files to copy
 entry has to name that path too, or new workspaces come up without it.
+`SANITY_TOKEN` belongs in the same file, but only draft mode reads it: see
+"Draft mode, and editing on the page" below.
 
 If you do not have it and need to see a visual change, stub the client:
 
@@ -320,6 +322,59 @@ should be cleaned up there:
 The portrait is a **hardcoded local import**
 (`components/layout/firm-section.tsx`, the block the home page and `/about`
 share), not CMS driven — swapping it needs a developer.
+
+### Draft mode, and editing on the page
+
+The Studio's **Presentation** tool renders this site in an iframe beside the
+form that feeds it, and every string on the page is a click target that selects
+the field behind it. The Studio half is `apps/studio/sanity.config.js`, in the
+other workspace; this half is the three pieces it talks to. Nothing validates
+one against the other, so a change to either route name has to be made twice.
+
+**`pages/api/draft.ts`** is the door. Presentation mints a one-time secret in
+the dataset, calls the route with it, and `validatePreviewUrl` reads it back and
+burns it. Anything less than a match is a `401`, including a dead token, which
+is otherwise a stack trace on a public endpoint. The exit is
+`pages/api/disable-draft.ts`, which needs no secret: the worst it can do is put
+someone back on the published site. Nothing links to either; Presentation drives
+the first, and the second is the way out for anyone who ends up holding the
+cookie outside the Studio.
+
+**`getClient(draft)` in `libs/clientApi.ts`** is what changes once the cookie is
+set. Same query, same locale, same shape back; a different client. It reads
+`perspective: "drafts"` off the API rather than the CDN, and it turns on
+**stega**, which encodes an edit link into every string it returns.
+
+Stega is why draft mode gates all of this rather than being on everywhere. Those
+links are invisible Unicode riding along *inside* the copy: on the published
+site they would end up in the HTML, in the markdown the agent surface serves,
+and in anything a reader copies off the page. `getClient()` without the flag is
+the ordinary published client and cannot produce them.
+
+**`libs/static-page-props.ts`** carries the flag from Next to the fetcher, so
+the six routes that go through it need no change of their own. The overlay in
+`_app.tsx` keys off `router.isPreview` instead, which is global, so it covers
+every route including the two that fetch outside `staticPageProps`.
+
+`/publications` is deliberately not wired: `libs/publications.ts` filters
+`drafts.**` and gates on `publishedAt` in GROQ, and those two would have to
+become conditional to show an unpublished post. Publication pages render inside
+Presentation, they just show what is live.
+
+**Two env vars, and one of them is new.** `NEXT_PUBLIC_SANITY_ID` as before, plus
+**`SANITY_TOKEN`**, a Sanity token with **Viewer** access, from
+sanity.io/manage. It is read per request rather than at module scope, so the
+published site neither needs it nor fails to boot without it. Only `/api/draft`
+does, and it answers `401` when the token is missing or stale. The one that was
+already in `.env` is revoked (`SIO-401-ANF`, "Session not found"); mint a fresh
+one before expecting any of this to work.
+
+**The overlay is not in the bundle a reader downloads.** It arrives through
+`next/dynamic` with `ssr: false`, because it pulls `@sanity/ui` and
+`styled-components`, the CSS-in-JS this repo otherwise does not have, and
+those belong in a chunk nothing fetches until draft mode renders it. A build
+that puts `styled-components` in `/_app` or `/` has lost that, and the symptom
+is a bundle that grew, so check `.next/build-manifest.json` rather than the page.
 
 ## The agent surface
 

--- a/apps/web/libs/clientApi.ts
+++ b/apps/web/libs/clientApi.ts
@@ -24,3 +24,40 @@ const clientApi = createClient({
 });
 
 export default clientApi;
+
+// The deployed Studio. stega encodes an edit link into every string a draft-mode
+// query returns, and the link has to resolve somewhere: inside Presentation the
+// overlay talks to its parent over postMessage, but a draft-mode visit made
+// outside the Studio falls back to this.
+const STUDIO_URL = "https://cabinet-ouaknine.sanity.studio";
+
+// `SANITY_TOKEN` is read per call rather than at module scope, because the
+// published site never needs it and must not fail to boot without it. A Viewer
+// token is enough; drafts are all it has to see.
+const draftToken = (): string => {
+	const token = process.env.SANITY_TOKEN;
+	if (!token) {
+		throw new Error("Draft mode needs SANITY_TOKEN, a Sanity token with Viewer access");
+	}
+
+	return token;
+};
+
+// Unpublished content, and no CDN in front of it: a draft that is one edit old
+// is the same as no draft at all. Deliberately without stega, because the
+// preview-secret handshake in pages/api/draft.ts compares a string it fetched
+// from this client, and stega would have encoded that string.
+export const previewClient = () =>
+	clientApi.withConfig({ token: draftToken(), useCdn: false, perspective: "drafts" });
+
+// What a page reads through. Draft mode swaps in a client that sees unpublished
+// content and stega-encodes an edit link into every string it returns, which is
+// what the overlay in pages/_app.tsx turns into a click target.
+//
+// Never the default: those links are invisible Unicode riding along inside the
+// copy, and they would end up in the published HTML, in the markdown the agent
+// surface serves, and in anything a reader copies off the page.
+export const getClient = (draft?: boolean) =>
+	draft
+		? previewClient().withConfig({ stega: { enabled: true, studioUrl: STUDIO_URL } })
+		: clientApi;

--- a/apps/web/libs/draft-redirect.test.ts
+++ b/apps/web/libs/draft-redirect.test.ts
@@ -1,0 +1,26 @@
+import { draftRedirect } from "./draft-redirect";
+
+test("keeps a path on this site", () => {
+	expect(draftRedirect("/")).toBe("/");
+	expect(draftRedirect("/contact")).toBe("/contact");
+	expect(draftRedirect("/en/expertise/droit-penal")).toBe("/en/expertise/droit-penal");
+	expect(draftRedirect("/publications?page=2")).toBe("/publications?page=2");
+});
+
+test("refuses anything that leaves the origin", () => {
+	// Protocol-relative: the browser reads the host that follows, not a path.
+	expect(draftRedirect("//evil.example")).toBe("/");
+	expect(draftRedirect("//evil.example/contact")).toBe("/");
+	// Backslashes normalise to slashes before the URL resolves.
+	expect(draftRedirect("/\\evil.example")).toBe("/");
+	expect(draftRedirect("\\\\evil.example")).toBe("/");
+	expect(draftRedirect("https://evil.example")).toBe("/");
+	expect(draftRedirect("javascript:alert(1)")).toBe("/");
+});
+
+test("falls back when the Studio sent nothing", () => {
+	expect(draftRedirect(undefined)).toBe("/");
+	expect(draftRedirect("")).toBe("/");
+	// A bare path with no leading slash is relative to /api/, not to the site.
+	expect(draftRedirect("contact")).toBe("/");
+});

--- a/apps/web/libs/draft-redirect.ts
+++ b/apps/web/libs/draft-redirect.ts
@@ -1,0 +1,20 @@
+// Where pages/api/draft.ts sends the browser once the preview secret checks out.
+//
+// The destination arrives as `sanity-preview-pathname` on the URL the Studio
+// built, which makes it caller-controlled: the route hands it straight to a
+// `Location` header, and a `Location` that leaves this origin is an open
+// redirect on a law practice's domain. Pure and separate from the route for the
+// same reason libs/proxy-route.ts is separate from proxy.ts, which is that the
+// decision is the part worth testing and the route cannot be imported.
+//
+// Only a path on this site survives. Everything else falls back to the home
+// page, which is where Presentation opens by default anyway.
+export const draftRedirect = (target: string | undefined): string => {
+	if (!target?.startsWith("/")) return "/";
+
+	// `//host` and `/\host` are both protocol-relative to a browser, and a
+	// backslash is normalised to a slash before the URL is resolved.
+	if (/^[/\\]/.test(target.slice(1))) return "/";
+
+	return target;
+};

--- a/apps/web/libs/expertise.ts
+++ b/apps/web/libs/expertise.ts
@@ -1,4 +1,4 @@
-import clientApi from "./clientApi";
+import { getClient } from "./clientApi";
 import { normaliseFields } from "./expertise-list";
 import type { ExpertiseDocument, ExpertiseDocumentRaw } from "./types";
 
@@ -11,8 +11,11 @@ const EXPERTISE_QUERY = `*[_type == "expertise" && language == $locale][0]{
 
 // Normalised once, where every consumer reads the list. The shaping is in
 // libs/expertise-list.ts, which is pure and therefore tested.
-export const fetchExpertise = async (locale?: string): Promise<ExpertiseDocument | null> => {
-	const doc = await clientApi.fetch<ExpertiseDocumentRaw | null>(EXPERTISE_QUERY, {
+export const fetchExpertise = async (
+	locale?: string,
+	draft?: boolean,
+): Promise<ExpertiseDocument | null> => {
+	const doc = await getClient(draft).fetch<ExpertiseDocumentRaw | null>(EXPERTISE_QUERY, {
 		locale: locale ?? "fr",
 	});
 	if (!doc) return null;

--- a/apps/web/libs/page-content.ts
+++ b/apps/web/libs/page-content.ts
@@ -1,4 +1,4 @@
-import clientApi from "./clientApi";
+import { getClient } from "./clientApi";
 import type { ContactDocument, HomeDocument, LegalDocument } from "./types";
 
 // One place for the page documents, so `getStaticProps` and the markdown
@@ -35,12 +35,22 @@ const LEGAL_QUERY = `*[_type == "legal" && language == $locale][0]{
 
 // Every one of these projects `[0]`, so a reachable Sanity with nothing
 // published resolves to null rather than rejecting.
-const fetchDocument = <T>(query: string, locale: string | undefined): Promise<T | null> =>
-	clientApi.fetch<T | null>(query, { locale: locale ?? "fr" });
+//
+// `draft` is the flag libs/static-page-props.ts reads off Next's draft mode. It
+// picks the client, and nothing else changes: same query, same locale, same
+// shape back. What differs is that the answer may be unpublished and that every
+// string in it carries a stega-encoded edit link.
+const fetchDocument = <T>(
+	query: string,
+	locale: string | undefined,
+	draft?: boolean,
+): Promise<T | null> => getClient(draft).fetch<T | null>(query, { locale: locale ?? "fr" });
 
-export const fetchHome = (locale?: string) => fetchDocument<HomeDocument>(HOME_QUERY, locale);
+export const fetchHome = (locale?: string, draft?: boolean) =>
+	fetchDocument<HomeDocument>(HOME_QUERY, locale, draft);
 
-export const fetchContact = (locale?: string) =>
-	fetchDocument<ContactDocument>(CONTACT_QUERY, locale);
+export const fetchContact = (locale?: string, draft?: boolean) =>
+	fetchDocument<ContactDocument>(CONTACT_QUERY, locale, draft);
 
-export const fetchLegal = (locale?: string) => fetchDocument<LegalDocument>(LEGAL_QUERY, locale);
+export const fetchLegal = (locale?: string, draft?: boolean) =>
+	fetchDocument<LegalDocument>(LEGAL_QUERY, locale, draft);

--- a/apps/web/libs/static-page-props.test.ts
+++ b/apps/web/libs/static-page-props.test.ts
@@ -34,6 +34,21 @@ test("the fetcher receives the locale, defaulting to undefined off a bare call",
 	expect(seen).toStrictEqual(["en", undefined]);
 });
 
+test("draft mode reaches the fetcher, which is what picks the client", async () => {
+	// The whole of what draft mode changes here: a boolean handed to the fetcher,
+	// which reads it as `getClient(draft)` in libs/clientApi.ts.
+	const seen: (boolean | undefined)[] = [];
+	const props = staticPageProps(async (_locale, draft) => {
+		seen.push(draft);
+		return { title: "T" };
+	}, "/");
+
+	await props({ locale: "fr", draftMode: true });
+	await props({ locale: "fr" });
+
+	expect(seen).toStrictEqual([true, undefined]);
+});
+
 test("a missing document is a 404 that expires", async () => {
 	// Without `revalidate` Next caches the not-found entry with no expiry, so the
 	// page stays a 404 until the next deploy. The key must be present.

--- a/apps/web/libs/static-page-props.ts
+++ b/apps/web/libs/static-page-props.ts
@@ -14,10 +14,16 @@
 // Pure: the fetcher is injected, so this is testable without the Sanity client.
 
 // The slice of Next's `GetStaticPropsContext` these routes read. Narrower on
-// purpose: nothing here should reach for preview data or a build id.
+// purpose: nothing here should reach for a build id or the preview payload.
+//
+// `draftMode` is the one exception, and it is a boolean rather than the payload:
+// it selects which client the fetcher reads through (libs/clientApi.ts) and
+// nothing more. Next sets it when the cookie from pages/api/draft.ts is present,
+// and serves the page on demand instead of from the ISR cache while it is.
 export type PageContext = {
 	locale?: string;
 	params?: Record<string, string | string[] | undefined>;
+	draftMode?: boolean;
 };
 
 export type PageResult<P> =
@@ -31,13 +37,13 @@ const pageName = (page: PageName, ctx?: PageContext): string =>
 
 export const staticPageProps =
 	<Data, Props = { data: Data }>(
-		fetcher: (locale?: string) => Promise<Data | null | undefined>,
+		fetcher: (locale?: string, draft?: boolean) => Promise<Data | null | undefined>,
 		page: PageName,
 		build?: (data: Data, ctx: PageContext) => Props | null,
 	) =>
 	async (ctx?: PageContext): Promise<PageResult<Props | { data: Data }>> => {
 		try {
-			const data = await fetcher(ctx?.locale);
+			const data = await fetcher(ctx?.locale, ctx?.draftMode);
 			if (!data) return { notFound: true, revalidate: 10 };
 
 			const props = build ? build(data, ctx ?? {}) : { data };

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -29,10 +29,13 @@
     "@portabletext/react": "8.0.1",
     "@sanity/client": "8.2.0",
     "@sanity/image-url": "2.1.1",
+    "@sanity/preview-url-secret": "4.1.5",
+    "@sanity/visual-editing": "6.1.1",
     "next": "16.3.2",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "react-icons": "4.4.0"
+    "react-icons": "4.4.0",
+    "styled-components": "catalog:"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.3",

--- a/apps/web/pages/_app.tsx
+++ b/apps/web/pages/_app.tsx
@@ -1,5 +1,7 @@
 import type { AppProps } from "next/app";
+import dynamic from "next/dynamic";
 import { Bodoni_Moda, Inter } from "next/font/google";
+import { useRouter } from "next/router";
 
 import Layout from "../components/layout/layout";
 import CookieContext from "../context/cookie-context";
@@ -34,10 +36,28 @@ const inter = Inter({
 	display: "swap",
 });
 
+// The click-to-edit overlay Sanity's Presentation tool drives. It reads the edit
+// links the draft-mode client stega-encodes into the copy (libs/clientApi.ts) and
+// turns each one into a target that selects the right field in the Studio beside
+// it.
+//
+// Loaded through `dynamic` with `ssr: false` on purpose: it pulls @sanity/ui and
+// styled-components, and neither belongs in the bundle a reader downloads. This
+// keeps them in a chunk nothing fetches until the branch below renders.
+const VisualEditing = dynamic(
+	() => import("@sanity/visual-editing/next-pages-router").then((m) => m.VisualEditing),
+	{ ssr: false },
+);
+
 function MyApp({ Component, pageProps }: AppProps<{ seo?: PageSeo }>) {
 	// A page that publishes an explicit alternate set knows which languages it has.
 	const alternates = pageProps?.seo?.alternates;
 	const locales = alternates ? Object.keys(alternates) : null;
+
+	// `isPreview` is Next's draft-mode flag, and it is global rather than a prop,
+	// so the overlay covers every route, including the two that fetch outside
+	// libs/static-page-props.ts, without each page having to pass it down.
+	const draft = useRouter().isPreview;
 
 	return (
 		<>
@@ -59,6 +79,7 @@ function MyApp({ Component, pageProps }: AppProps<{ seo?: PageSeo }>) {
 					</LocalesContext>
 				</NavContext>
 			</CookieContext>
+			{draft ? <VisualEditing /> : null}
 		</>
 	);
 }

--- a/apps/web/pages/api/disable-draft.ts
+++ b/apps/web/pages/api/disable-draft.ts
@@ -1,0 +1,10 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+// The way back out of draft mode. Clearing the cookie needs no secret: the worst
+// an unauthenticated call can do is put a reader back on the published site,
+// which is where they already were.
+export default function disableDraft(_req: NextApiRequest, res: NextApiResponse) {
+	res.setDraftMode({ enable: false });
+	res.writeHead(307, { Location: "/" });
+	res.end();
+}

--- a/apps/web/pages/api/draft.ts
+++ b/apps/web/pages/api/draft.ts
@@ -1,0 +1,41 @@
+import { validatePreviewUrl } from "@sanity/preview-url-secret";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { previewClient } from "../../libs/clientApi";
+import { draftRedirect } from "../../libs/draft-redirect";
+
+// The door Presentation opens to put this site in its iframe. The Studio mints a
+// one-time secret in the dataset, appends it to this URL, and `validatePreviewUrl`
+// reads it back and burns it; without that handshake anyone could set the cookie
+// and read the practice's unpublished copy.
+//
+// The exit is pages/api/disable-draft.ts. Nothing on the public site links to
+// either, because Presentation drives both.
+
+export default async function enableDraft(req: NextApiRequest, res: NextApiResponse) {
+	if (!req.url) {
+		res.status(400).send("Missing URL");
+		return;
+	}
+
+	// Every way this can fail (no secret, a stale one, a token the dataset no
+	// longer recognises) means the same thing to the caller, and an uncaught
+	// throw here answers a public endpoint with a stack trace. The reason is
+	// worth exactly one server-side line.
+	let redirectTo: string | undefined;
+	try {
+		const validated = await validatePreviewUrl(previewClient(), req.url);
+		if (!validated.isValid) throw new Error("secret did not match");
+		redirectTo = validated.redirectTo;
+	} catch (err) {
+		console.error("draft mode refused", err);
+		res.status(401).send("Invalid secret");
+		return;
+	}
+
+	// Next stops serving this browser from the ISR cache while the cookie is set,
+	// and renders every page on demand instead. `getStaticProps` sees it as
+	// `draftMode`, which is what libs/static-page-props.ts reads.
+	res.setDraftMode({ enable: true });
+	res.writeHead(307, { Location: draftRedirect(redirectTo) });
+	res.end();
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ catalogs:
     react-dom:
       specifier: 19.2.8
       version: 19.2.8
+    styled-components:
+      specifier: 6.5.3
+      version: 6.5.3
 
 importers:
 
@@ -35,7 +38,7 @@ importers:
         specifier: 6.10.1
         version: 6.10.1(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.103.1)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@2.20.1(@types/react@19.2.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react@19.2.18)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.2)(jiti@2.7.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(sass@1.103.1)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(typescript@5.9.3)(vitest@4.1.11(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.103.1)(tsx@4.23.12)(yaml@2.9.0)))
       styled-components:
-        specifier: 6.5.3
+        specifier: 'catalog:'
         version: 6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     devDependencies:
       '@sanity/eslint-config-studio':
@@ -59,6 +62,12 @@ importers:
       '@sanity/image-url':
         specifier: 2.1.1
         version: 2.1.1
+      '@sanity/preview-url-secret':
+        specifier: 4.1.5
+        version: 4.1.5(@sanity/client@8.2.0(vitest@4.1.11(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.103.1)(tsx@4.23.12)(yaml@2.9.0))))
+      '@sanity/visual-editing':
+        specifier: 6.1.1
+        version: 6.1.1(@sanity/client@8.2.0(vitest@4.1.11(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.103.1)(tsx@4.23.12)(yaml@2.9.0))))(@types/react@19.2.18)(next@16.3.2(@babel/core@7.29.7)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.103.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(typescript@5.9.3)
       next:
         specifier: 16.3.2
         version: 16.3.2(@babel/core@7.29.7)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.103.1)
@@ -71,6 +80,9 @@ importers:
       react-icons:
         specifier: 4.4.0
         version: 4.4.0(react@19.2.8)
+      styled-components:
+        specifier: 'catalog:'
+        version: 6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     devDependencies:
       '@biomejs/biome':
         specifier: 2.5.3
@@ -2562,6 +2574,12 @@ packages:
       react: ^19.2.2
       sanity: ^6.0.0-0
 
+  '@sanity/visual-editing-csm@3.0.17':
+    resolution: {integrity: sha512-QE62zkJ388KlBbZiej7mYwmGKRYEe+NOnaTfIiVu8PJYbFBkyOEyttAxjclBYji0+utFmHIl77hZ6DxujtLlYg==}
+    engines: {node: '>=20.19 <22 || >=22.12'}
+    peerDependencies:
+      '@sanity/client': ^7.26.2 || ^8.0.0
+
   '@sanity/visual-editing-types@2.1.1':
     resolution: {integrity: sha512-t/Aa2HclwUHzNY/CGeQMEVDb4Dc5izI7SwdqwTeSSMc+f0hRgAa2PG3PuBOmpyCta0GGMm7febk4FMWqF+iwaA==}
     engines: {node: '>=20.19 <22 || >=22.12'}
@@ -2570,6 +2588,30 @@ packages:
       '@sanity/types': '*'
     peerDependenciesMeta:
       '@sanity/types':
+        optional: true
+
+  '@sanity/visual-editing@6.1.1':
+    resolution: {integrity: sha512-1uhcCgFENyNioy/ztr+y2NIE7z4YyCrTSwYXhU2ha2G+a/90hhuPEEQHShktVGvJ2UvoG+zDRDXOOLCkRTvAzA==}
+    engines: {node: '>=22.12'}
+    peerDependencies:
+      '@sanity/client': ^7.26.2 || ^8.0.0
+      '@sveltejs/kit': '>= 2'
+      next: '>=16.0.0-0'
+      react: ^19.2
+      react-dom: ^19.2
+      react-router: '>= 7'
+      styled-components: ^6.1
+      svelte: '>= 4'
+    peerDependenciesMeta:
+      '@sanity/client':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      react-router:
+        optional: true
+      svelte:
         optional: true
 
   '@sanity/workbench-cli@2.1.0':
@@ -5376,6 +5418,14 @@ packages:
   uuidv7@0.4.4:
     resolution: {integrity: sha512-jjRGChg03uGp9f6wQYSO8qXkweJwRbA5WRuEQE8xLIiehIzIIi23qZSzsyvZPCPoFqkeLtZuz7Plt1LGukAInA==}
     hasBin: true
+
+  valibot@1.4.2:
+    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   verkit@0.3.2:
     resolution: {integrity: sha512-zj/ob3UsvJGN0whEAKFp53REA5X66hvffVqoCtVQAakJKnKlH+/PcOfMoFwIG/o4rElqLv/ycAFlx8ZlXUorCg==}
@@ -8288,6 +8338,11 @@ snapshots:
       '@sanity/client': 7.26.2
       '@sanity/uuid': 3.0.3
 
+  '@sanity/preview-url-secret@4.1.5(@sanity/client@8.2.0(vitest@4.1.11(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.103.1)(tsx@4.23.12)(yaml@2.9.0))))':
+    dependencies:
+      '@sanity/client': 8.2.0(vitest@4.1.11(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.103.1)(tsx@4.23.12)(yaml@2.9.0)))
+      '@sanity/uuid': 3.0.3
+
   '@sanity/prism-groq@1.1.2': {}
 
   '@sanity/runtime-cli@17.9.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@types/node@24.13.3)(@types/react@19.2.18)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.2)(rolldown@1.2.5)(sass@1.103.1)(tsx@4.23.12)(typescript@5.9.3)(vitest@4.1.11(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.103.1)(tsx@4.23.12)(yaml@2.9.0)))(yaml@2.9.0)':
@@ -8542,11 +8597,54 @@ snapshots:
       - react-dom
       - styled-components
 
+  '@sanity/visual-editing-csm@3.0.17(@sanity/client@8.2.0(vitest@4.1.11(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.103.1)(tsx@4.23.12)(yaml@2.9.0))))(@sanity/types@6.10.1(@types/react@19.2.18))(typescript@5.9.3)':
+    dependencies:
+      '@sanity/client': 8.2.0(vitest@4.1.11(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.103.1)(tsx@4.23.12)(yaml@2.9.0)))
+      '@sanity/visual-editing-types': 2.1.1(@sanity/client@8.2.0(vitest@4.1.11(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.103.1)(tsx@4.23.12)(yaml@2.9.0))))(@sanity/types@6.10.1(@types/react@19.2.18))
+      valibot: 1.4.2(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@sanity/types'
+      - typescript
+
   '@sanity/visual-editing-types@2.1.1(@sanity/client@7.26.2)(@sanity/types@6.10.1(@types/react@19.2.18))':
     dependencies:
       '@sanity/client': 7.26.2
     optionalDependencies:
       '@sanity/types': 6.10.1(@types/react@19.2.18)
+
+  '@sanity/visual-editing-types@2.1.1(@sanity/client@8.2.0(vitest@4.1.11(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.103.1)(tsx@4.23.12)(yaml@2.9.0))))(@sanity/types@6.10.1(@types/react@19.2.18))':
+    dependencies:
+      '@sanity/client': 8.2.0(vitest@4.1.11(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.103.1)(tsx@4.23.12)(yaml@2.9.0)))
+    optionalDependencies:
+      '@sanity/types': 6.10.1(@types/react@19.2.18)
+
+  '@sanity/visual-editing@6.1.1(@sanity/client@8.2.0(vitest@4.1.11(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.103.1)(tsx@4.23.12)(yaml@2.9.0))))(@types/react@19.2.18)(next@16.3.2(@babel/core@7.29.7)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.103.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(typescript@5.9.3)':
+    dependencies:
+      '@sanity/comlink': 4.0.3
+      '@sanity/icons': 5.2.1(react@19.2.8)
+      '@sanity/mutate': 0.18.1(xstate@5.32.5)
+      '@sanity/presentation-comlink': 2.2.3(@sanity/types@6.10.1(@types/react@19.2.18))
+      '@sanity/preview-url-secret': 4.1.5(@sanity/client@8.2.0(vitest@4.1.11(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.103.1)(tsx@4.23.12)(yaml@2.9.0))))
+      '@sanity/types': 6.10.1(@types/react@19.2.18)
+      '@sanity/ui': 4.0.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@sanity/visual-editing-csm': 3.0.17(@sanity/client@8.2.0(vitest@4.1.11(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.103.1)(tsx@4.23.12)(yaml@2.9.0))))(@sanity/types@6.10.1(@types/react@19.2.18))(typescript@5.9.3)
+      '@sanity/visual-editing-types': 2.1.1(@sanity/client@8.2.0(vitest@4.1.11(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.103.1)(tsx@4.23.12)(yaml@2.9.0))))(@sanity/types@6.10.1(@types/react@19.2.18))
+      '@vercel/stega': 1.1.0
+      dequal: 2.0.3
+      lodash-es: 4.18.1
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-is: 19.2.8
+      rxjs: 7.8.2
+      scroll-into-view-if-needed: 3.1.0
+      styled-components: 6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      xstate: 5.32.5
+    optionalDependencies:
+      '@sanity/client': 8.2.0(vitest@4.1.11(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.103.1)(tsx@4.23.12)(yaml@2.9.0)))
+      next: 16.3.2(@babel/core@7.29.7)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.103.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - typescript
 
   '@sanity/workbench-cli@2.1.0(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.103.1)(tsx@4.23.12)(yaml@2.9.0)))(@types/node@24.13.3)(@types/react@19.2.18)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.103.1)(tsx@4.23.12)(typescript@5.9.3)(vitest@4.1.11(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.103.1)(tsx@4.23.12)(yaml@2.9.0)))(yaml@2.9.0)':
     dependencies:
@@ -11539,6 +11637,10 @@ snapshots:
   uuid@14.0.2: {}
 
   uuidv7@0.4.4: {}
+
+  valibot@1.4.2(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
 
   verkit@0.3.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,11 +1,16 @@
 packages:
   - "apps/*"
 
-# React is the one dependency the site and the studio genuinely share. The
-# catalog is what stops them drifting onto two different 19.x behind a caret.
+# The dependencies the site and the studio genuinely share. The catalog is what
+# stops them drifting onto two different 19.x behind a caret.
+#
+# styled-components is here for the same reason React is: the studio has always
+# needed it, and the site now does too, as the peer @sanity/visual-editing
+# declares. Neither imports it directly; both have to resolve the same one.
 catalog:
   react: 19.2.8
   react-dom: 19.2.8
+  styled-components: 6.5.3
 
 # The studio's Vite toolchain. Nothing in the site needs a postinstall, so this
 # stays an allowlist rather than a blanket `dangerouslyAllowAllBuilds`.


### PR DESCRIPTION
Reimplements **#34** and **0xbulma/back-ouaknine#3** as one change. Both were branched before #33 merged `back-ouaknine` into `apps/studio`: #34's base is `db6b2d9`, three commits behind `main`, and it still edits a root `package.json`, a root `CLAUDE.md` and a `yarn.lock`; #3 targets a repo that no longer receives commits. Neither can be merged as-is.

The feature is unchanged. What is new is that the two halves are one diff, which is what merging the repos was for.

## The two halves

**`apps/studio/sanity.config.js`** puts the site in an iframe beside the form that feeds it. `presentationTool` ships in `sanity` 6, so it adds no dependency. `previewMode.enable` is the handshake: Presentation mints a one-time secret in the dataset and calls `/api/draft` with it.

**`apps/web/pages/api/draft.ts`** is what answers. `validatePreviewUrl` reads the secret back and burns it; anything short of a match is a `401`, including a dead token, which would otherwise answer a public endpoint with a stack trace. Where it sends the browser afterwards arrives as `sanity-preview-pathname` on a URL the Studio built, so it is caller-controlled and `//evil.example` is a working open redirect. **`libs/draft-redirect.ts`** refuses anything that leaves this origin, and is pure and separate from the route for the same reason `libs/proxy-route.ts` is separate from `proxy.ts`, which is that a route cannot be imported by a test.

**`getClient(draft)` in `libs/clientApi.ts`** is what the cookie changes. Same query, same locale, same shape back; a client that reads `perspective: "drafts"` off the API rather than the CDN, and turns on **stega**, which encodes an edit link into every string it returns.

Stega is why this is gated on draft mode rather than on everywhere. Those links are invisible Unicode riding along *inside* the copy: on the published site they would end up in the HTML, in the markdown the agent surface serves, and in anything a reader copies off the page.

`libs/static-page-props.ts` carries the flag from Next to the fetcher, so the six routes through it need no change of their own. The overlay in `_app.tsx` keys off `router.isPreview` instead, which is global, so it covers every route including the two that fetch outside `staticPageProps`.

## What the monorepo changed

| | |
|---|---|
| Paths | `libs/` and `pages/` are `apps/web/libs/` and `apps/web/pages/` |
| Lockfile | one root `pnpm-lock.yaml`, not a `yarn.lock` |
| `styled-components` | into the **catalog**. The studio has always needed it, the site now does too as the `@sanity/visual-editing` peer, and the catalog is what stops the two resolving different ones. Pinned at the studio's 6.5.3, not #34's 6.1.19 |
| Local dev | `.conductor/settings.toml` sets `SANITY_STUDIO_PREVIEW_URL=http://localhost:$CONDUCTOR_PORT`, so the Studio frames the site in the same workspace rather than production. Takes effect once this is on `main`, since the Mac app reads `settings.toml` from the default branch |
| Docs | the new section is in `apps/web/CLAUDE.md`, and the root `CLAUDE.md` "The seam" gains the second seam: the Studio's `previewUrl` points at the site's `/api/draft`, and nothing validates that pairing either |

#34's `.env.local`-at-the-repository-root hunk is dropped. `apps/web/CLAUDE.md` already says `apps/web/.env.local`, because Next resolves its env file from the app directory.

## What this does not do

- **`/publications` stays on published content.** `libs/publications.ts` filters `drafts.**` and gates on `publishedAt` in GROQ; both would have to become conditional to show an unpublished post. Those pages render inside Presentation, they just show what is live.
- **No inline typing on the page.** Sanity does not do that in any version. Clicking a string selects its field in the form beside the iframe.

## Before this works

`SANITY_TOKEN` has to be a Sanity token with **Viewer** access, in `apps/web/.env`. The one already there is revoked (`SIO-401-ANF`, "Session not found"). It is read per request rather than at module scope, so the published site neither needs it nor fails to boot without it.

That is also the ceiling on what could be verified: **the authenticated draft render is the one path not exercised below.**

## Checks

`pnpm verify` (the whole of CI) is green: **171 tests pass** across 22 files, up from 167/21. The four new ones are `libs/draft-redirect.test.ts` (3) and a `draftMode` case in `libs/static-page-props.test.ts`. Biome: 12 warnings, the same 12 as on `main`. Studio ESLint: 37 warnings, 0 errors, none in `sanity.config.js`. `pnpm --filter web build` and `pnpm --filter studio build` both green.

Against `next start`:

| | |
|---|---|
| `/api/draft` with no secret | `401`, body `Invalid secret`, no `Set-Cookie` |
| `/api/draft` with a bogus secret + `//evil.example` | `401` |
| `/api/disable-draft` | `307` to `/` |
| Published HTML, six page types + the markdown surface | **0 stega characters** in all seven |
| `styled-components` in `build-manifest.json` | exactly **1** chunk, referenced by no page entry (not `/_app`, not `/`) |

Closes #34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
