### PR TITLE
fix: two things found while deploying Presentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Three asymmetries are deliberate, and named here so nobody tries to fix them:
 |---|---|
 | `engines.node` only in `apps/web` | Vercel reads it from the deployed workspace. A second copy would be a second thing to forget. CI points at that one file |
 | Biome only covers `apps/web` | Its rules assume TypeScript and the React Compiler. The studio's own ESLint config covers the studio |
-| Only the site has a `deploy` through git | The studio deploys with `pnpm --filter studio deploy`, to Sanity's hosting, by hand |
+| Only the site has a `deploy` through git | The studio deploys with `pnpm --filter studio run deploy`, to Sanity's hosting, by hand |
 
 ## The seam
 
@@ -112,8 +112,18 @@ Vercel builds `apps/web` only. Its **Root Directory** must be `apps/web`, with
 lockfile. Nothing in the repo sets that, so it is a dashboard change and the
 build breaks without it.
 
-The studio deploys separately with `pnpm studio:deploy`, to Sanity's own
-hosting. It is not part of the Vercel build and CI never builds it.
+The studio deploys separately, to Sanity's own hosting. It is not part of the
+Vercel build and CI never builds it.
+
+```bash
+pnpm --filter studio run deploy
+```
+
+**`run` is not optional there.** `deploy` is one of pnpm's own commands, so
+`pnpm --filter studio deploy` never reaches the script: it tries to deploy the
+workspace as a bundle and fails with `ERR_PNPM_INVALID_DEPLOY_TARGET`. `run`
+is what says "the script by that name". Every other task in this repo is safe
+to call bare, because none of the rest collides with a builtin.
 
 ## History
 

--- a/apps/studio/CLAUDE.md
+++ b/apps/studio/CLAUDE.md
@@ -15,7 +15,7 @@ dataset `production`, deployed to Sanity's own hosting rather than to Vercel.
 | Language | **JavaScript**, ESM (`"type": "module"`). No TypeScript, so no `typecheck` |
 | Lint | **ESLint** with `@sanity/eslint-config-studio`. Biome does not run here |
 | Tests | `node --test`. No Vitest, no test framework |
-| Deploy | `pnpm --filter studio deploy`, pinned to the existing studio by `appId` |
+| Deploy | `pnpm --filter studio run deploy`, pinned to the existing studio by `appId` |
 
 `presentationTool` puts the site in an iframe beside the form that feeds it, and
 turns every string on the page into a click target for its field. That needs

--- a/apps/studio/README.md
+++ b/apps/studio/README.md
@@ -5,7 +5,7 @@ Sanity Studio v6 for the Alice Ouaknine site. Project `46fx2dmc`, dataset
 
 ```bash
 pnpm --filter studio dev      # :3333
-pnpm --filter studio deploy   # to Sanity's hosting
+pnpm --filter studio run deploy   # to Sanity's hosting
 ```
 
 `CLAUDE.md` beside this file carries the rest.

--- a/apps/web/libs/clientApi.test.ts
+++ b/apps/web/libs/clientApi.test.ts
@@ -1,0 +1,40 @@
+// libs/clientApi.ts builds a client at module scope, and createClient refuses a
+// blank projectId, so the env has to exist before the import. Hence `await
+// import` rather than a top-level one.
+const loadClientApi = async () => {
+	process.env.NEXT_PUBLIC_SANITY_ID = "test-project";
+	return import("./clientApi");
+};
+
+test("no SANITY_TOKEN is its own failure, not a bad secret", async () => {
+	// pages/api/draft.ts branches on this class to answer 500 rather than 401.
+	// An operator who never set the token is not a caller with a wrong secret,
+	// and telling them so is the difference between a fixable error and a hunt.
+	const { previewClient, DraftModeNotConfigured } = await loadClientApi();
+
+	process.env.SANITY_TOKEN = "";
+	expect(() => previewClient()).toThrow(DraftModeNotConfigured);
+
+	delete process.env.SANITY_TOKEN;
+	expect(() => previewClient()).toThrow(DraftModeNotConfigured);
+});
+
+test("a token present is enough to build the client", async () => {
+	const { previewClient } = await loadClientApi();
+
+	process.env.SANITY_TOKEN = "sk-not-a-real-token";
+	// Whether Sanity accepts it is Sanity's answer, not this module's: the point
+	// is that it gets far enough to ask, which is what makes the 401 mean
+	// "rejected" rather than "never configured".
+	expect(previewClient().config().token).toBe("sk-not-a-real-token");
+});
+
+test("stega is on only for a draft read", async () => {
+	const { getClient } = await loadClientApi();
+	process.env.SANITY_TOKEN = "sk-not-a-real-token";
+
+	// The published client cannot produce edit links; that is the whole reason
+	// draft mode gates it. Invisible Unicode in published HTML is the failure.
+	expect(getClient().config().stega.enabled).toBe(false);
+	expect(getClient(true).config().stega.enabled).toBe(true);
+});

--- a/apps/web/libs/clientApi.ts
+++ b/apps/web/libs/clientApi.ts
@@ -31,14 +31,22 @@ export default clientApi;
 // outside the Studio falls back to this.
 const STUDIO_URL = "https://cabinet-ouaknine.sanity.studio";
 
+// The server has no token, which is a different thing from the caller having a
+// bad secret, and pages/api/draft.ts answers the two differently. Its own class
+// so that decision is made on identity rather than on matching message text.
+export class DraftModeNotConfigured extends Error {
+	constructor() {
+		super("Draft mode needs SANITY_TOKEN, a Sanity token with Viewer access");
+		this.name = "DraftModeNotConfigured";
+	}
+}
+
 // `SANITY_TOKEN` is read per call rather than at module scope, because the
 // published site never needs it and must not fail to boot without it. A Viewer
 // token is enough; drafts are all it has to see.
 const draftToken = (): string => {
 	const token = process.env.SANITY_TOKEN;
-	if (!token) {
-		throw new Error("Draft mode needs SANITY_TOKEN, a Sanity token with Viewer access");
-	}
+	if (!token) throw new DraftModeNotConfigured();
 
 	return token;
 };

--- a/apps/web/pages/api/draft.ts
+++ b/apps/web/pages/api/draft.ts
@@ -1,6 +1,6 @@
 import { validatePreviewUrl } from "@sanity/preview-url-secret";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { previewClient } from "../../libs/clientApi";
+import { DraftModeNotConfigured, previewClient } from "../../libs/clientApi";
 import { draftRedirect } from "../../libs/draft-redirect";
 
 // The door Presentation opens to put this site in its iframe. The Studio mints a
@@ -17,16 +17,32 @@ export default async function enableDraft(req: NextApiRequest, res: NextApiRespo
 		return;
 	}
 
-	// Every way this can fail (no secret, a stale one, a token the dataset no
-	// longer recognises) means the same thing to the caller, and an uncaught
-	// throw here answers a public endpoint with a stack trace. The reason is
-	// worth exactly one server-side line.
+	// A bad secret and an unconfigured server are not the same failure, and
+	// collapsing them into one 401 is how an operator who never set SANITY_TOKEN
+	// gets told their secret is invalid. `validatePreviewUrl` builds its client
+	// before it looks at the URL, so a missing token throws first and never
+	// reaches Sanity: the two are indistinguishable from outside unless the
+	// status says so.
+	//
+	// The 500 gives away that draft mode exists here and is not set up, which is
+	// worth nothing to a caller: without a token the endpoint cannot grant draft
+	// mode to anyone, correct secret or not.
+	//
+	// Everything else (no secret, a stale one, a token the dataset no longer
+	// recognises) is one 401. An uncaught throw would answer a public endpoint
+	// with a stack trace, so the reason is worth exactly one server-side line.
 	let redirectTo: string | undefined;
 	try {
 		const validated = await validatePreviewUrl(previewClient(), req.url);
 		if (!validated.isValid) throw new Error("secret did not match");
 		redirectTo = validated.redirectTo;
 	} catch (err) {
+		if (err instanceof DraftModeNotConfigured) {
+			console.error("draft mode is not configured", err);
+			res.status(500).send("Draft mode is not configured");
+			return;
+		}
+
 		console.error("draft mode refused", err);
 		res.status(401).send("Invalid secret");
 		return;


### PR DESCRIPTION
Two things found while deploying the Presentation change (#35) to prod.

## 1. The studio deploy command in this repo never ran

`pnpm --filter studio deploy` appears in three docs and works in none of them. `deploy` is one of **pnpm's own commands**, so the filter never reaches the package script:

```
$ pnpm --filter studio deploy
[ERR_PNPM_INVALID_DEPLOY_TARGET] This command requires one parameter
```

The root `CLAUDE.md` separately offered `pnpm studio:deploy`, which is not a script in any `package.json` here.

The working form is `pnpm --filter studio run deploy`. `run` is what says "the script by that name" rather than "the builtin". Nothing else in the repo collides with a pnpm builtin, which is why this went unnoticed. Fixed in `CLAUDE.md` (twice), `apps/studio/CLAUDE.md` and `apps/studio/README.md`, with a note on why `run` is load-bearing.

Verified by running it: the Studio is live at https://cabinet-ouaknine.sanity.studio/ with Presentation.

## 2. `/api/draft` could not tell "no token" from "bad secret"

Both answered `401 Invalid secret`. `validatePreviewUrl` builds its client **before** it parses the URL:

```js
function createClientWithConfig(client) {
  if (!client.config().token) throw TypeError("`client` must have a `token` specified")
  ...
}
```

so a missing `SANITY_TOKEN` throws before any request reaches Sanity, and the two failures are indistinguishable from outside. The result is that setting draft mode up for the first time reports the one thing it cannot be, the secret. That is exactly the wall hit while wiring prod.

A missing token is now `DraftModeNotConfigured` and a **500**, matched on class rather than message text. Everything else stays one 401 with a single server-side log line.

The 500 does reveal that draft mode exists here and is unconfigured. That buys a caller nothing: with no token the endpoint cannot grant draft mode to anyone, right secret or not.

Proven against a real `next start`, both branches:

| | |
|---|---|
| empty/absent `SANITY_TOKEN`, any secret | `500 Draft mode is not configured` |
| token present, secret wrong or stale | `401 Invalid secret` |

`libs/clientApi.test.ts` is new: it covers that branch, and covers that stega stays **off** for a published read, which is the failure that would put invisible Unicode into the HTML a reader copies.

`pnpm verify` green, **174 tests** (was 171), warning counts unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)