### PR TITLE
fix: finish Presentation coverage across the site

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,12 @@ production, and `.conductor/settings.toml` points it at the local one. The site
 side of it is documented under "Draft mode, and editing on the page" in
 `apps/web/CLAUDE.md`.
 
+`apps/studio/locations.js` is the return leg: which URL each document is shown
+at, so the Studio can link from a form to its page. It has to spell those URLs
+the way the site does, which means copies of `slugify` and `withLocale` from
+`apps/web/libs`. `apps/studio/test/slug-parity.test.js` pins the first against
+the real file and the second against a table.
+
 ## Conductor
 
 `.conductor/settings.toml` and `.worktreeinclude` at the root configure the

--- a/apps/studio/CLAUDE.md
+++ b/apps/studio/CLAUDE.md
@@ -79,6 +79,16 @@ Two tools exist for that seam and they look at opposite ends of it:
   part of `verify`. `apps/web/CLAUDE.md` lists the fields the redesign stopped
   rendering; they should be cleaned up here.
 
+`locations.js` crosses the same seam in the other direction: it tells
+Presentation which URL each document is shown at, so the form carries a link
+straight to its page. Building that URL needs the site's `slugify` and
+`withLocale`, and there is no shared package to take them from, so both are
+copies. `test/slug-parity.test.js` loads `apps/web/libs/slug.ts` directly —
+Node strips the types and that file imports nothing — and fails if the two ever
+disagree. `withLocale` is checked against a table instead, because
+`apps/web/libs/site-url.ts` opens with an extensionless relative import Node
+will not resolve.
+
 ## Conventions
 
 - Schema types are plain, import-free objects. That is what lets the parity test

--- a/apps/studio/locations.js
+++ b/apps/studio/locations.js
@@ -1,0 +1,122 @@
+import {defineLocations} from 'sanity/presentation'
+
+/**
+ * Which URL on the site each document appears at.
+ *
+ * Presentation uses this for the "Used on" panel above the form: without it the
+ * Studio can frame the site but cannot tell an editor where the document they
+ * have open actually shows up, and for a post it genuinely cannot be guessed —
+ * the slug is derived from the title by code that lives in the other workspace.
+ *
+ * The seam this crosses is the one the root CLAUDE.md names: `apps/studio` and
+ * `apps/web` share no package, so both `slugify` and `withLocale` below are
+ * copies. `test/slug-parity.test.js` loads the originals and fails if the two
+ * ever disagree, because two slugifiers that differ by one character produce a
+ * dead link in the Studio and nothing else.
+ */
+
+/** Copy of apps/web/libs/slug.ts. Pinned by test/slug-parity.test.js. */
+export const slugify = value =>
+  (value ?? '')
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+
+/** Copy of `withLocale` in apps/web/libs/site-url.ts. French goes unprefixed. */
+export const withLocale = (language, path) =>
+  language === 'fr' || language === undefined ? path : `/${language}${path === '/' ? '' : path}`
+
+/** A document that is one language and sits at fixed paths. */
+const staticPage = (pages) =>
+  defineLocations({
+    select: {language: 'language'},
+    resolve: (doc) =>
+      doc?.language
+        ? {locations: pages.map(([title, path]) => ({title, href: withLocale(doc.language, path)}))}
+        : {message: 'Set the language before this page has a URL.', tone: 'caution'},
+  })
+
+export const locations = {
+  // The home document feeds two routes: the hero at `/` and the same firm
+  // section again, under its own heading, at `/about`.
+  home: staticPage([
+    ['Home', '/'],
+    ['The firm', '/about'],
+  ]),
+
+  // `/expertise` renders the first field and canonicalises onto it, which is why
+  // it is not in the sitemap. It is still the URL this document is framed at.
+  expertise: staticPage([['Expertise', '/expertise']]),
+  contact: staticPage([['Contact', '/contact']]),
+  legal: staticPage([['Legal notice', '/legal']]),
+  articles: staticPage([['Publications', '/publications']]),
+  iska: staticPage([['ISKA network', '/iska']]),
+
+  // A field of expertise carries no language of its own: it is the list that
+  // references it that has one, so the language is read back up the reference.
+  // An item no list references has no page, and saying so is more use than an
+  // empty panel.
+  expertiseItem: defineLocations({
+    select: {
+      title: 'title',
+      language: '*[_type == "expertise" && references(^._id)][0].language',
+    },
+    resolve: (doc) => {
+      const slug = slugify(doc?.title)
+      if (!slug) return {message: 'Give this field a title to give it a URL.', tone: 'caution'}
+      if (!doc?.language) {
+        return {
+          message: 'No expertise list references this field, so the site does not show it.',
+          tone: 'caution',
+        }
+      }
+
+      return {
+        locations: [
+          {title: doc.title.trim(), href: withLocale(doc.language, `/expertise/${slug}`)},
+        ],
+      }
+    },
+  }),
+
+  // One post is up to two pages. The site lists it in a language only when it
+  // has a body in that language, so the same rule decides the locations: an
+  // English-only piece has no French URL, and offering one would frame a 404.
+  //
+  // The slug is the same in both, and mirrors the projection in
+  // apps/web/libs/publications.ts. `slug.current` is legacy and usually absent,
+  // which is why the title is what it normally falls through to.
+  post: defineLocations({
+    select: {
+      slug: 'coalesce(slug.current, contentfr.titlefr, contenten.titleen)',
+      titlefr: 'contentfr.titlefr',
+      titleen: 'contenten.titleen',
+      hasFr: 'defined(contentfr.bodyfr)',
+      hasEn: 'defined(contenten.bodyen)',
+    },
+    resolve: (doc) => {
+      const slug = slugify(doc?.slug)
+      if (!slug) return {message: 'Give this post a title to give it a URL.', tone: 'caution'}
+
+      const locations = [
+        doc.hasFr && {
+          title: `${doc.titlefr?.trim() || 'Publication'} (français)`,
+          href: withLocale('fr', `/publications/${slug}`),
+        },
+        doc.hasEn && {
+          title: `${doc.titleen?.trim() || 'Publication'} (English)`,
+          href: withLocale('en', `/publications/${slug}`),
+        },
+      ].filter(Boolean)
+
+      // A post with a title and no body anywhere is filtered out of every list
+      // the site builds, so it has no page yet rather than a broken one.
+      return locations.length
+        ? {locations}
+        : {message: 'Write a body in at least one language to give this post a page.', tone: 'caution'}
+    },
+  }),
+}

--- a/apps/studio/sanity.config.js
+++ b/apps/studio/sanity.config.js
@@ -4,6 +4,7 @@ import {presentationTool} from 'sanity/presentation'
 import {visionTool} from '@sanity/vision'
 
 import {schemaTypes} from './schemas'
+import {locations} from './locations.js'
 
 export default defineConfig({
   name: 'default',
@@ -29,11 +30,18 @@ export default defineConfig({
     // knows and which Vite does not populate; SANITY_STUDIO_* is where Vite puts
     // them. The default is production, so a deployed Studio needs no env at all;
     // .conductor/settings.toml sets it to the local site in a workspace.
+    //
+    // `resolve.locations` is the other direction: which URL a document is shown
+    // at, so the form carries an "Used on" link straight to its page. Without it
+    // the only way in is to browse the framed site, and a publication's slug is
+    // derived from its title by code in the other workspace, so an editor cannot
+    // work it out. See locations.js.
     presentationTool({
       previewUrl: {
         initial: import.meta.env.SANITY_STUDIO_PREVIEW_URL || 'https://www.ouaknine-avocats.com',
         previewMode: {enable: '/api/draft'},
       },
+      resolve: {locations},
     }),
     visionTool(),
   ],

--- a/apps/studio/test/slug-parity.test.js
+++ b/apps/studio/test/slug-parity.test.js
@@ -1,0 +1,67 @@
+/**
+ * Pins the two helpers `locations.js` copies from the site.
+ *
+ * `apps/studio` and `apps/web` share no package, on purpose, so the URL a
+ * document location points at is built by a second copy of `slugify` and
+ * `withLocale`. Two slugifiers that disagree by one character produce a link
+ * that 404s from inside the Studio and nowhere else, which is the kind of
+ * failure nobody reports because it looks like the preview being flaky.
+ *
+ * `slugify` is compared against the real thing: apps/web/libs/slug.ts is
+ * TypeScript, but Node strips the types and the file imports nothing, so it
+ * loads straight from the other workspace. That is the copy worth pinning, and
+ * it is pinned properly.
+ *
+ * `withLocale` cannot be loaded the same way — apps/web/libs/site-url.ts opens
+ * with `import { SITE_URL } from "./site"`, and Node's stripper does not resolve
+ * an extensionless relative import. It is three lines, so it is checked against
+ * a table instead. Weaker, and the reason is here rather than left to be
+ * rediscovered.
+ */
+import {test, describe} from 'node:test'
+import assert from 'node:assert/strict'
+
+import {slugify, withLocale} from '../locations.js'
+
+const {slugify: webSlugify} = await import('../../web/libs/slug.ts')
+
+// Real titles from the dataset, plus the shapes that break a naive slugifier:
+// accents, a trailing space, punctuation runs, an apostrophe, empty values.
+const TITLES = [
+  'Droit pénal général',
+  'Enquêtes internes',
+  'Press and media law    ',
+  'Défense des ressortissants américains et des étrangers anglophones',
+  'Guide de survie en garde à vue - épisode 1 : connaître ses droits',
+  "Prise illégale d'intérêts",
+  'Cyber-criminalité',
+  '  ',
+  '',
+  null,
+  undefined,
+]
+
+describe('the studio builds the same URLs as the site', () => {
+  test('slugify agrees with apps/web/libs/slug.ts on every title', () => {
+    for (const title of TITLES) {
+      assert.equal(slugify(title), webSlugify(title), `slugify(${JSON.stringify(title)})`)
+    }
+  })
+
+  test('withLocale matches apps/web/libs/site-url.ts', () => {
+    // French unprefixed, English under /en, and the locale root spelled `/en`
+    // rather than `/en/` — that last one is the case the site special-cases.
+    const expected = [
+      ['fr', '/', '/'],
+      ['fr', '/about', '/about'],
+      ['en', '/', '/en'],
+      ['en', '/about', '/en/about'],
+      ['en', '/expertise/droit-penal-general', '/en/expertise/droit-penal-general'],
+      [undefined, '/publications/x', '/publications/x'],
+    ]
+
+    for (const [language, path, want] of expected) {
+      assert.equal(withLocale(language, path), want, `withLocale(${language}, ${path})`)
+    }
+  })
+})

--- a/apps/web/libs/publications.ts
+++ b/apps/web/libs/publications.ts
@@ -1,4 +1,4 @@
-import clientApi from "./clientApi";
+import clientApi, { getClient } from "./clientApi";
 import { otherLocale, withSlug } from "./publication-fields";
 import { slugify } from "./slug";
 import type { Locale, PortableText, PublicationDocument, PublicationMeta } from "./types";
@@ -42,9 +42,22 @@ const projection = (locale: string | undefined): string => {
 
 // A dated document that is not a draft. `publishedAt` is what holds a piece back
 // until its release date, so an undated one is not published at all.
-const PUBLISHED = `_type == "post"
+//
+// The `drafts.**` clause only bites under the `raw` perspective, which nothing
+// here uses. Draft mode reads through `drafts`, and that perspective resolves a
+// draft over its published twin and returns it under the published id, so the
+// clause never sees a prefixed one. Verified against the dataset: the same
+// filter answers 10 documents published and 13 in draft mode.
+//
+// The release date is the one clause draft mode drops, and it has to: the whole
+// point of Presentation is to look at what is not live yet, and a piece dated
+// next month is exactly that. Left in, the Studio frames a 404 for it and the
+// editor has no way to see the page they are writing. On the dataset today that
+// is 45 of 58 posts. `defined(publishedAt)` stays either way — the list orders
+// by it, and an undated post has no place in that order.
+const published = (draft?: boolean): string => `_type == "post"
   && defined(publishedAt)
-  && dateTime(publishedAt) < dateTime(now())
+  ${draft ? "" : "&& dateTime(publishedAt) < dateTime(now())"}
   && !(_id in path("drafts.**"))`;
 
 // Only what the reader can actually read. A French press cutting has no English
@@ -54,9 +67,12 @@ const readable = (post: PublicationDocument): boolean => Boolean(post?.hasBody);
 // Every publication in a language, without the prose. This is what a list needs,
 // and a list is most of what the section does: the index renders rows, the rail
 // renders links, the sitemap renders slugs.
-export const fetchPublications = async (locale?: string): Promise<PublicationMeta[]> => {
-	const posts = await clientApi.fetch<PublicationDocument[] | null>(
-		`*[${PUBLISHED}] | order(publishedAt desc) ${projection(locale)}`,
+export const fetchPublications = async (
+	locale?: string,
+	draft?: boolean,
+): Promise<PublicationMeta[]> => {
+	const posts = await getClient(draft).fetch<PublicationDocument[] | null>(
+		`*[${published(draft)}] | order(publishedAt desc) ${projection(locale)}`,
 	);
 
 	return (posts ?? []).filter(readable).map(withSlug);
@@ -68,11 +84,12 @@ export const fetchPublications = async (locale?: string): Promise<PublicationMet
 export const fetchPublicationBody = async (
 	locale: string | undefined,
 	id: string,
+	draft?: boolean,
 ): Promise<PortableText | null> => {
 	const l = safeLocale(locale);
 
-	const post = await clientApi.fetch<{ body?: PortableText | null } | null>(
-		`*[${PUBLISHED} && _id == $id][0]{ "body": content${l}.body${l} }`,
+	const post = await getClient(draft).fetch<{ body?: PortableText | null } | null>(
+		`*[${published(draft)} && _id == $id][0]{ "body": content${l}.body${l} }`,
 		{ id },
 	);
 
@@ -83,6 +100,11 @@ export const fetchPublicationBody = async (
 // being read. It applies exactly the filters the destination page applies, so it
 // can never resolve an id to a page that will 404 — which is what a permanent
 // redirect to a locale with no body did.
+//
+// The published client on purpose, and the one fetcher here that takes no
+// `draft`: this route only ever answers with a redirect, so there is nothing to
+// preview, and resolving a draft-only post here would mint a 308 to a URL the
+// published site does not serve.
 export const fetchPublicationById = async (
 	locale: string | undefined,
 	id: string,
@@ -90,7 +112,7 @@ export const fetchPublicationById = async (
 	const l = safeLocale(locale);
 
 	const post = await clientApi.fetch<{ slug?: string | null; hasBody?: boolean } | null>(
-		`*[${PUBLISHED} && _id == $id][0]{
+		`*[${published()} && _id == $id][0]{
       "slug": coalesce(slug.current, contentfr.titlefr, contenten.titleen),
       "hasBody": defined(content${l}.body${l})
     }`,

--- a/apps/web/pages/publications/[slug].tsx
+++ b/apps/web/pages/publications/[slug].tsx
@@ -33,9 +33,14 @@ export const getStaticPaths: GetStaticPaths = async ({ locales = LOCALES }) => {
 	}
 };
 
+// `draftMode` reaches all three fetches below, so an unpublished post renders
+// here and every string on it carries the edit link Presentation clicks. This
+// route builds its own props rather than going through
+// libs/static-page-props.ts, so the client swap is its own to make.
 export const getStaticProps: GetStaticProps<PublicationPageProps> = async ({
 	params,
 	locale: requested,
+	draftMode,
 }) => {
 	const slug = String(params?.slug ?? "");
 	const locale = resolveLocale(requested);
@@ -48,8 +53,8 @@ export const getStaticProps: GetStaticProps<PublicationPageProps> = async ({
 		// is emitted, and a missing alternate is recoverable; a cached 404 is not,
 		// so it must not be able to take the page down with it.
 		const [posts, translations] = await Promise.all([
-			fetchPublications(locale),
-			fetchPublications(twin).catch((err) => {
+			fetchPublications(locale, draftMode),
+			fetchPublications(twin, draftMode).catch((err) => {
 				console.error("publication twin locale", twin, slug, err);
 				return [];
 			}),
@@ -60,7 +65,7 @@ export const getStaticProps: GetStaticProps<PublicationPageProps> = async ({
 		if (!meta) return { notFound: true, revalidate: 60 };
 
 		// Only now, and only this one document's prose.
-		const body = await fetchPublicationBody(locale, meta._id);
+		const body = await fetchPublicationBody(locale, meta._id, draftMode);
 
 		if (!body) return { notFound: true, revalidate: 60 };
 

--- a/apps/web/pages/publications/index.tsx
+++ b/apps/web/pages/publications/index.tsx
@@ -2,7 +2,7 @@ import type { GetStaticProps } from "next";
 import type { PublicationsIndexProps } from "../../components/layout/publications-index";
 import PublicationsIndex from "../../components/layout/publications-index";
 import publicationsContent from "../../content/publicationsContent.json";
-import clientApi from "../../libs/clientApi";
+import { getClient } from "../../libs/clientApi";
 import { fetchPublications } from "../../libs/publications";
 import { resolveLocale } from "../../libs/site-url";
 import type { PublicationsDocument } from "../../libs/types";
@@ -15,18 +15,25 @@ const PAGE_QUERY = `*[_type == "articles" && language == $locale][0]{
   title
 }`;
 
-export const getStaticProps: GetStaticProps<PublicationsIndexProps> = async ({ locale }) => {
+// `draftMode` is what puts this route in Presentation: it swaps in the client
+// that sees unpublished posts and stega-encodes an edit link into every string,
+// the same swap libs/static-page-props.ts makes for the pages that use it. This
+// route builds its own props, so it has to make the swap itself.
+export const getStaticProps: GetStaticProps<PublicationsIndexProps> = async ({
+	locale,
+	draftMode,
+}) => {
 	try {
 		const [content, posts] = await Promise.all([
 			// The page renders without its CMS copy (the fallback below); only a
 			// failure to fetch the posts genuinely leaves it with nothing.
-			clientApi
+			getClient(draftMode)
 				.fetch<PublicationsDocument | null>(PAGE_QUERY, { locale: locale ?? "fr" })
 				.catch((err) => {
 					console.error("publications index copy", locale, err);
 					return null;
 				}),
-			fetchPublications(locale),
+			fetchPublications(locale, draftMode),
 		]);
 
 		// The copy query is allowed to fail, so it must have somewhere to fall back


### PR DESCRIPTION
Two commits. The first fixes routes Presentation could not reach; the second tells the Studio where each document lives.

## Motivation

PR #35 put the site inside the Studio's Presentation tool, but it only reached the routes that fetch through `libs/static-page-props.ts`. `pages/publications/index.tsx` and `pages/publications/[slug].tsx` build their own props and reached for `clientApi` directly, so Presentation framed them **published and read-only**: no unpublished posts, and not one string carrying an edit link. `pages/_app.tsx` even names those two routes as the ones that fetch outside the helper.

The release date turned out to be the larger half. `dateTime(publishedAt) < dateTime(now())` is what holds a piece back until its release, and it applied in draft mode too, so a post scheduled for next month 404'd inside the Studio. On the dataset today that is **45 of 58 posts** an editor could not preview.

And once a draft post renders, you still have to find it. Its URL is `slugify` over a title, derived in `apps/web`, so an editor opening one in the Studio could not work out where it lived. The only way in was scrolling 58 rows of the framed index.

The expertise routes were already fine. Verified rather than assumed: `slugify` strips stega back to an identical slug, so the `[slug]` lookup still matches when every string carries an encoded edit link.

## Solution

**Draft mode reaches the publications routes.** `fetchPublications` and `fetchPublicationBody` take a `draft` flag and read through `getClient(draft)`, the same swap `staticPageProps` makes. Both pages read `draftMode` off the context and thread it. `PUBLISHED` becomes `published(draft)` and drops the release-date clause when draft is on; `defined(publishedAt)` stays either way, since the list orders by it.

`fetchPublicationById` deliberately keeps the published client: that route only ever answers with a redirect, so there is nothing to preview, and resolving a draft-only post would mint a 308 to a URL the live site does not serve.

**`resolve.locations` says where each document appears** (`apps/studio/locations.js`), so the form carries a link straight to its page.

- An `expertiseItem` carries no language of its own, so it is read back up the reference from the list that holds it. The location points at the one correct locale instead of offering both and letting one 404.
- A post is one document but up to two pages, so the rule the site lists it by decides its locations too: an English-only piece gets no French URL.
- Where there is no page (no title, no body in either language, an item no list references, a page document with no language) the panel says why rather than linking somewhere broken.

Two things checked rather than guessed:

- `!(_id in path("drafts.**"))` needed no change. Under `perspective: drafts` Sanity strips the prefix before the filter sees it, so the clause is a no-op there and only bites under `raw`, which nothing uses. The same filter answers 10 documents published and 13 in draft mode.
- `@vercel/stega` v1 encodes into four zero-width BMP characters, not the tag plane. Worth knowing for anyone probing this later: the wrong range reads as "no edit links anywhere", including on pages that already worked.

## The seam this adds

`apps/studio` and `apps/web` share no package by design, so building those URLs means copies of `slugify` and `withLocale`. That is the exact failure the repo's own docs warn about: two slugifiers differing by one character make a link that 404s only from inside the Studio.

`apps/studio/test/slug-parity.test.js` pins it. `apps/web/libs/slug.ts` imports nothing and Node strips its types, so the test loads the **real function** and compares them on 11 titles. `withLocale` gets a table instead, because `apps/web/libs/site-url.ts` opens with an extensionless relative import Node will not resolve. That is weaker, and the reason is written in the test rather than left to be rediscovered.

## Verification

Driven against the live dataset through the real `/api/draft` handshake, with a preview secret minted the way the Studio mints one.

- All five routes carry edit links, including `/` as a control that already worked.
- Decoded targets are correct: `type=post`, `type=expertiseItem` and `type=articles`, each with its own document id and field `path`. 39 distinct on `/publications` before the release-date fix, 179 after.
- 48 draft-only posts now render; 7 of 8 sampled go 404 published to 200 in draft. The 8th is correct behaviour: an English-only post 404s at the French URL and returns 200 at `/en/publications/...`.
- Locations: **22 of 22** URLs answer 200 across all eight document types, generated by running each resolver's real `select` projection against the dataset and feeding the result to its `resolve`. Draft posts: **6 of 6** are 404 public and 200 in Presentation.
- The published surface is unchanged: the index still lists 10 posts, the markdown representation 10, a scheduled post 404s publicly, and the sitemap carries zero scheduled slugs.

`sanity build` succeeds. `pnpm verify` green in both workspaces: 175 web tests, 6 studio tests (up from 4).

## After merging

The Studio needs `pnpm --filter studio run deploy` for locations to reach editors.

One cosmetic note: the new studio test prints a `MODULE_TYPELESS_PACKAGE_JSON` warning during `verify`, from importing the site's `.ts`. Silencing it would mean adding `"type": "module"` to `apps/web/package.json`, which is not worth doing for a warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)